### PR TITLE
feat(themes): add ANSI color theme using terminal palette

### DIFF
--- a/docs/content/using-kimun/themes.md
+++ b/docs/content/using-kimun/themes.md
@@ -20,7 +20,8 @@ The following themes are included out of the box:
 - **Solarized Dark**
 - **Solarized Light**
 - **Nord**
-- **ANSI** *(uses your terminal's own 16-color palette)*
+- **ANSI Dark**
+- **ANSI Light**
 
 Switch between them via the Settings screen in the TUI, or by setting the `theme` field in your config file:
 
@@ -73,13 +74,15 @@ color_search_match = "#a6e3a1" # Highlighted search match text
 
 ### Color Formats
 
-Colors can be specified in three formats:
+Colors can be specified in the following formats:
 
-| Format | Example |
-|---|---|
-| 6-digit hex | `"#1e1e2e"` |
-| 3-digit hex (shorthand) | `"#abc"` → expands to `#aabbcc` |
-| RGB function | `"rgb(30, 30, 46)"` |
+| Format | Example | Notes |
+|---|---|---|
+| 6-digit hex | `"#1e1e2e"` | |
+| 3-digit hex (shorthand) | `"#abc"` | Expands to `#aabbcc` |
+| RGB function | `"rgb(30, 30, 46)"` | |
+| ANSI index | `"ansi:4"` | 0-255 |
+| Terminal default | `"reset"` | Uses the terminal's default fg or bg |
 
 ### Activating a Custom Theme
 

--- a/docs/content/using-kimun/themes.md
+++ b/docs/content/using-kimun/themes.md
@@ -20,6 +20,7 @@ The following themes are included out of the box:
 - **Solarized Dark**
 - **Solarized Light**
 - **Nord**
+- **ANSI** *(uses your terminal's own 16-color palette)*
 
 Switch between them via the Settings screen in the TUI, or by setting the `theme` field in your config file:
 

--- a/docs/content/using-kimun/themes.md
+++ b/docs/content/using-kimun/themes.md
@@ -20,8 +20,7 @@ The following themes are included out of the box:
 - **Solarized Dark**
 - **Solarized Light**
 - **Nord**
-- **ANSI Dark**
-- **ANSI Light**
+- **ANSI** — adapts to your terminal's configured 16-color palette (works for both light and dark terminal themes)
 
 Switch between them via the Settings screen in the TUI, or by setting the `theme` field in your config file:
 

--- a/example/config.toml
+++ b/example/config.toml
@@ -22,7 +22,7 @@
 #
 # ─────────────────────────────────────────────────────────────────────────────
 config_version = 3
-theme = "dark"
+theme = "ANSI"
 cache_dir = "."
 history_dir = "history"
 autosave_interval_secs = 5
@@ -36,12 +36,12 @@ journal_sort_order = "descending"
 [global]
 current_workspace = "personal"
 
-[workspaces.work]
-path = "work"
-created = "2026-04-01T00:00:00Z"
-
 [workspaces.personal]
 path = "personal"
+created = "2026-04-01T00:00:00Z"
+
+[workspaces.work]
+path = "work"
 created = "2026-04-01T00:00:00Z"
 
 [key_bindings]

--- a/example/config.toml
+++ b/example/config.toml
@@ -36,12 +36,12 @@ journal_sort_order = "descending"
 [global]
 current_workspace = "personal"
 
-[workspaces.personal]
-path = "personal"
-created = "2026-04-01T00:00:00Z"
-
 [workspaces.work]
 path = "work"
+created = "2026-04-01T00:00:00Z"
+
+[workspaces.personal]
+path = "personal"
 created = "2026-04-01T00:00:00Z"
 
 [key_bindings]

--- a/tui/src/settings/mod.rs
+++ b/tui/src/settings/mod.rs
@@ -247,6 +247,7 @@ impl AppSettings {
             Theme::solarized_dark(),
             Theme::solarized_light(),
             Theme::nord(),
+            Theme::ansi_16(),
         ];
         list.append(&mut Self::load_custom_themes());
         // Merge the user's default.toml override if present.

--- a/tui/src/settings/mod.rs
+++ b/tui/src/settings/mod.rs
@@ -269,7 +269,8 @@ impl AppSettings {
             Theme::solarized_dark(),
             Theme::solarized_light(),
             Theme::nord(),
-            Theme::ansi(),
+            Theme::ansi_dark(),
+            Theme::ansi_light(),
         ];
         list.append(&mut Self::load_custom_themes());
         // Merge the user's default.toml override if present.

--- a/tui/src/settings/mod.rs
+++ b/tui/src/settings/mod.rs
@@ -269,7 +269,7 @@ impl AppSettings {
             Theme::solarized_dark(),
             Theme::solarized_light(),
             Theme::nord(),
-            Theme::ansi_16(),
+            Theme::ansi(),
         ];
         list.append(&mut Self::load_custom_themes());
         // Merge the user's default.toml override if present.

--- a/tui/src/settings/mod.rs
+++ b/tui/src/settings/mod.rs
@@ -269,8 +269,7 @@ impl AppSettings {
             Theme::solarized_dark(),
             Theme::solarized_light(),
             Theme::nord(),
-            Theme::ansi_dark(),
-            Theme::ansi_light(),
+            Theme::ansi(),
         ];
         list.append(&mut Self::load_custom_themes());
         // Merge the user's default.toml override if present.

--- a/tui/src/settings/themes.rs
+++ b/tui/src/settings/themes.rs
@@ -3,10 +3,13 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::Display;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ThemeColor {
-    r: u8,
-    g: u8,
-    b: u8,
+pub enum ThemeColor {
+    Rgb(u8, u8, u8),
+    /// Terminal ANSI color index (0–15 for the standard palette, up to 255 for
+    /// 256-color mode). The actual color is determined by the user's terminal.
+    Ansi(u8),
+    /// The terminal's default foreground or background color.
+    Reset,
 }
 
 impl Serialize for ThemeColor {
@@ -14,8 +17,13 @@ impl Serialize for ThemeColor {
     where
         S: Serializer,
     {
-        let hex = format!("#{:02x}{:02x}{:02x}", self.r, self.g, self.b);
-        serializer.serialize_str(&hex)
+        match self {
+            ThemeColor::Rgb(r, g, b) => {
+                serializer.serialize_str(&format!("#{:02x}{:02x}{:02x}", r, g, b))
+            }
+            ThemeColor::Ansi(n) => serializer.serialize_str(&format!("ansi:{}", n)),
+            ThemeColor::Reset => serializer.serialize_str("reset"),
+        }
     }
 }
 
@@ -31,18 +39,23 @@ impl<'de> Deserialize<'de> for ThemeColor {
 
 impl ThemeColor {
     pub fn new(r: u8, g: u8, b: u8) -> Self {
-        ThemeColor { r, g, b }
+        ThemeColor::Rgb(r, g, b)
     }
 
-    /// Convert to a ratatui `Color::Rgb` value for use in widget styles.
+    /// Convert to the corresponding ratatui `Color`.
     pub fn to_ratatui(&self) -> Color {
-        Color::Rgb(self.r, self.g, self.b)
+        match self {
+            ThemeColor::Rgb(r, g, b) => Color::Rgb(*r, *g, *b),
+            ThemeColor::Ansi(n) => Color::Indexed(*n),
+            ThemeColor::Reset => Color::Reset,
+        }
     }
 
     /// Parse a color from a string in various formats:
     /// - RGB: "rgb(255, 128, 0)"
     /// - 3-char hex: "#abc" (expanded to #aabbcc)
     /// - 6-char hex: "#aabbcc"
+    /// - ANSI index: "ansi:4"
     pub fn from_string(s: &str) -> Result<Self, String> {
         let s = s.trim();
 
@@ -50,6 +63,12 @@ impl ThemeColor {
             Self::from_hex(s)
         } else if s.starts_with("rgb(") && s.ends_with(')') {
             Self::from_rgb_string(s)
+        } else if s == "reset" {
+            Ok(ThemeColor::Reset)
+        } else if let Some(rest) = s.strip_prefix("ansi:") {
+            rest.parse::<u8>()
+                .map(ThemeColor::Ansi)
+                .map_err(|_| format!("Invalid ANSI color index: {}", rest))
         } else {
             Err(format!("Invalid color format: {}", s))
         }
@@ -86,7 +105,7 @@ impl ThemeColor {
         let b = u8::from_str_radix(&hex[2..3].repeat(2), 16)
             .map_err(|_| format!("Invalid hex character in blue component: {}", &hex[2..3]))?;
 
-        Ok(ThemeColor { r, g, b })
+        Ok(ThemeColor::Rgb(r, g, b))
     }
 
     /// Parse 6-character hex color (e.g., "aabbcc")
@@ -102,7 +121,7 @@ impl ThemeColor {
         let b = u8::from_str_radix(&hex[4..6], 16)
             .map_err(|_| format!("Invalid hex characters in blue component: {}", &hex[4..6]))?;
 
-        Ok(ThemeColor { r, g, b })
+        Ok(ThemeColor::Rgb(r, g, b))
     }
 
     /// Parse RGB string format (e.g., "rgb(255, 128, 0)")
@@ -128,13 +147,17 @@ impl ThemeColor {
             .parse::<u8>()
             .map_err(|_| format!("Invalid blue value: {}", parts[2]))?;
 
-        Ok(ThemeColor { r, g, b })
+        Ok(ThemeColor::Rgb(r, g, b))
     }
 }
 
 impl Display for ThemeColor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "rgb({},{},{})", self.r, self.g, self.b)
+        match self {
+            ThemeColor::Rgb(r, g, b) => write!(f, "rgb({},{},{})", r, g, b),
+            ThemeColor::Ansi(n) => write!(f, "ansi:{}", n),
+            ThemeColor::Reset => write!(f, "reset"),
+        }
     }
 }
 
@@ -405,6 +428,27 @@ impl Theme {
             color_search_match: ThemeColor::from_string("#a3be8c").unwrap(),
         }
     }
+
+    /// Uses the terminal's 16 ANSI colors so the theme adapts to whatever
+    /// palette the user has configured in their terminal emulator.
+    pub fn ansi_16() -> Self {
+        Theme {
+            name: "ANSI 16".to_string(),
+            bg: ThemeColor::Reset,
+            bg_panel: ThemeColor::Ansi(0),    // black
+            bg_selected: ThemeColor::Ansi(4), // blue
+            fg: ThemeColor::Reset,
+            fg_secondary: ThemeColor::Ansi(7),  // white
+            fg_muted: ThemeColor::Ansi(8),      // bright black
+            fg_selected: ThemeColor::Ansi(15),  // bright white
+            border: ThemeColor::Ansi(8),        // bright black
+            border_focused: ThemeColor::Ansi(6), // cyan
+            accent: ThemeColor::Ansi(6),         // cyan
+            color_directory: ThemeColor::Ansi(12), // bright blue
+            color_journal_date: ThemeColor::Ansi(10), // bright green
+            color_search_match: ThemeColor::Ansi(11), // bright yellow
+        }
+    }
 }
 
 #[cfg(test)]
@@ -431,98 +475,121 @@ mod tests {
 
     #[test]
     fn test_from_hex_6char() {
-        let color = ThemeColor::from_string("#ff8800").unwrap();
-        assert_eq!(color.r, 255);
-        assert_eq!(color.g, 136);
-        assert_eq!(color.b, 0);
+        assert_eq!(
+            ThemeColor::from_string("#ff8800").unwrap(),
+            ThemeColor::Rgb(255, 136, 0)
+        );
     }
 
     #[test]
     fn test_from_hex_6char_lowercase() {
-        let color = ThemeColor::from_string("#abcdef").unwrap();
-        assert_eq!(color.r, 171);
-        assert_eq!(color.g, 205);
-        assert_eq!(color.b, 239);
+        assert_eq!(
+            ThemeColor::from_string("#abcdef").unwrap(),
+            ThemeColor::Rgb(171, 205, 239)
+        );
     }
 
     #[test]
     fn test_from_hex_6char_uppercase() {
-        let color = ThemeColor::from_string("#ABCDEF").unwrap();
-        assert_eq!(color.r, 171);
-        assert_eq!(color.g, 205);
-        assert_eq!(color.b, 239);
+        assert_eq!(
+            ThemeColor::from_string("#ABCDEF").unwrap(),
+            ThemeColor::Rgb(171, 205, 239)
+        );
     }
 
     #[test]
     fn test_from_hex_3char() {
-        let color = ThemeColor::from_string("#f80").unwrap();
-        assert_eq!(color.r, 255);
-        assert_eq!(color.g, 136);
-        assert_eq!(color.b, 0);
+        assert_eq!(
+            ThemeColor::from_string("#f80").unwrap(),
+            ThemeColor::Rgb(255, 136, 0)
+        );
     }
 
     #[test]
     fn test_from_hex_3char_expansion() {
-        let color = ThemeColor::from_string("#abc").unwrap();
-        assert_eq!(color.r, 170);
-        assert_eq!(color.g, 187);
-        assert_eq!(color.b, 204);
+        assert_eq!(
+            ThemeColor::from_string("#abc").unwrap(),
+            ThemeColor::Rgb(170, 187, 204)
+        );
     }
 
     #[test]
     fn test_from_hex_3char_black() {
-        let color = ThemeColor::from_string("#000").unwrap();
-        assert_eq!(color.r, 0);
-        assert_eq!(color.g, 0);
-        assert_eq!(color.b, 0);
+        assert_eq!(
+            ThemeColor::from_string("#000").unwrap(),
+            ThemeColor::Rgb(0, 0, 0)
+        );
     }
 
     #[test]
     fn test_from_hex_3char_white() {
-        let color = ThemeColor::from_string("#fff").unwrap();
-        assert_eq!(color.r, 255);
-        assert_eq!(color.g, 255);
-        assert_eq!(color.b, 255);
+        assert_eq!(
+            ThemeColor::from_string("#fff").unwrap(),
+            ThemeColor::Rgb(255, 255, 255)
+        );
     }
 
     #[test]
     fn test_from_rgb_string() {
-        let color = ThemeColor::from_string("rgb(255, 128, 0)").unwrap();
-        assert_eq!(color.r, 255);
-        assert_eq!(color.g, 128);
-        assert_eq!(color.b, 0);
+        assert_eq!(
+            ThemeColor::from_string("rgb(255, 128, 0)").unwrap(),
+            ThemeColor::Rgb(255, 128, 0)
+        );
     }
 
     #[test]
     fn test_from_rgb_string_no_spaces() {
-        let color = ThemeColor::from_string("rgb(255,128,0)").unwrap();
-        assert_eq!(color.r, 255);
-        assert_eq!(color.g, 128);
-        assert_eq!(color.b, 0);
+        assert_eq!(
+            ThemeColor::from_string("rgb(255,128,0)").unwrap(),
+            ThemeColor::Rgb(255, 128, 0)
+        );
     }
 
     #[test]
     fn test_from_rgb_string_extra_spaces() {
-        let color = ThemeColor::from_string("rgb( 255 , 128 , 0 )").unwrap();
-        assert_eq!(color.r, 255);
-        assert_eq!(color.g, 128);
-        assert_eq!(color.b, 0);
+        assert_eq!(
+            ThemeColor::from_string("rgb( 255 , 128 , 0 )").unwrap(),
+            ThemeColor::Rgb(255, 128, 0)
+        );
     }
 
     #[test]
     fn test_from_rgb_string_min_max() {
-        let color = ThemeColor::from_string("rgb(0, 255, 0)").unwrap();
-        assert_eq!(color.r, 0);
-        assert_eq!(color.g, 255);
-        assert_eq!(color.b, 0);
+        assert_eq!(
+            ThemeColor::from_string("rgb(0, 255, 0)").unwrap(),
+            ThemeColor::Rgb(0, 255, 0)
+        );
     }
 
     #[test]
     fn test_from_string_with_whitespace() {
-        let color = ThemeColor::from_string("  #ff8800  ").unwrap();
-        assert_eq!(color.r, 255);
-        assert_eq!(color.g, 136);
-        assert_eq!(color.b, 0);
+        assert_eq!(
+            ThemeColor::from_string("  #ff8800  ").unwrap(),
+            ThemeColor::Rgb(255, 136, 0)
+        );
+    }
+
+    #[test]
+    fn test_from_ansi_index() {
+        assert_eq!(
+            ThemeColor::from_string("ansi:4").unwrap(),
+            ThemeColor::Ansi(4)
+        );
+        assert_eq!(
+            ThemeColor::from_string("ansi:255").unwrap(),
+            ThemeColor::Ansi(255)
+        );
+    }
+
+    #[test]
+    fn test_from_reset() {
+        assert_eq!(ThemeColor::from_string("reset").unwrap(), ThemeColor::Reset);
+    }
+
+    #[test]
+    fn test_ansi_to_ratatui() {
+        assert_eq!(ThemeColor::Ansi(4).to_ratatui(), Color::Indexed(4));
+        assert_eq!(ThemeColor::Reset.to_ratatui(), Color::Reset);
     }
 
     #[test]
@@ -586,10 +653,7 @@ mod tests {
 
     #[test]
     fn test_new_constructor() {
-        let color = ThemeColor::new(255, 128, 0);
-        assert_eq!(color.r, 255);
-        assert_eq!(color.g, 128);
-        assert_eq!(color.b, 0);
+        assert_eq!(ThemeColor::new(255, 128, 0), ThemeColor::Rgb(255, 128, 0));
     }
 
     #[test]
@@ -619,9 +683,7 @@ mod tests {
         }
         let toml_str = r###"color = "#3b82f6""###;
         let wrapper: Wrapper = toml::from_str(toml_str).unwrap();
-        assert_eq!(wrapper.color.r, 59);
-        assert_eq!(wrapper.color.g, 130);
-        assert_eq!(wrapper.color.b, 246);
+        assert_eq!(wrapper.color, ThemeColor::Rgb(59, 130, 246));
     }
 
     #[test]
@@ -710,9 +772,7 @@ mod tests {
         }
         let toml_str = r###"color = "#ABCDEF""###;
         let wrapper: Wrapper = toml::from_str(toml_str).unwrap();
-        assert_eq!(wrapper.color.r, 171);
-        assert_eq!(wrapper.color.g, 205);
-        assert_eq!(wrapper.color.b, 239);
+        assert_eq!(wrapper.color, ThemeColor::Rgb(171, 205, 239));
     }
 
     #[test]
@@ -723,14 +783,13 @@ mod tests {
         }
         let toml_str = r###"color = "#abc""###;
         let wrapper: Wrapper = toml::from_str(toml_str).unwrap();
-        assert_eq!(wrapper.color.r, 170);
-        assert_eq!(wrapper.color.g, 187);
-        assert_eq!(wrapper.color.b, 204);
+        assert_eq!(wrapper.color, ThemeColor::Rgb(170, 187, 204));
     }
 
     #[test]
     fn test_all_builtin_themes_serialize() {
         let themes = vec![
+            Theme::ansi_16(),
             Theme::gruvbox_dark(),
             Theme::gruvbox_light(),
             Theme::catppuccin_mocha(),

--- a/tui/src/settings/themes.rs
+++ b/tui/src/settings/themes.rs
@@ -55,6 +55,8 @@ impl ThemeColor {
     /// - RGB: "rgb(255, 128, 0)"
     /// - 3-char hex: "#abc" (expanded to #aabbcc)
     /// - 6-char hex: "#aabbcc"
+    /// - ANSI index: "ansi:4" (0–255)
+    /// - Terminal default: "reset"
     pub fn from_string(s: &str) -> Result<Self, String> {
         let s = s.trim();
 
@@ -62,6 +64,12 @@ impl ThemeColor {
             Self::from_hex(s)
         } else if s.starts_with("rgb(") && s.ends_with(')') {
             Self::from_rgb_string(s)
+        } else if s == "reset" {
+            Ok(ThemeColor::Reset)
+        } else if let Some(rest) = s.strip_prefix("ansi:") {
+            rest.parse::<u8>()
+                .map(ThemeColor::Ansi)
+                .map_err(|_| format!("Invalid ANSI color index: {}", rest))
         } else {
             Err(format!("Invalid color format: {}", s))
         }
@@ -423,12 +431,12 @@ impl Theme {
     }
 
     /// Uses the terminal's 16 ANSI colors so the theme adapts to whatever
-    /// palette the user has configured in their terminal emulator.
-    pub fn ansi() -> Self {
+    /// palette the user has configured in their terminal emulator (dark variant).
+    pub fn ansi_dark() -> Self {
         Theme {
-            name: "ANSI".to_string(),
+            name: "ANSI Dark".to_string(),
             bg: ThemeColor::Reset,
-            bg_panel: ThemeColor::Ansi(0),    // black
+            bg_panel: ThemeColor::Ansi(0),
             bg_selected: ThemeColor::Ansi(4), // blue
             fg: ThemeColor::Reset,
             fg_secondary: ThemeColor::Ansi(7),        // white
@@ -440,6 +448,27 @@ impl Theme {
             color_directory: ThemeColor::Ansi(12),    // bright blue
             color_journal_date: ThemeColor::Ansi(10), // bright green
             color_search_match: ThemeColor::Ansi(11), // bright yellow
+        }
+    }
+
+    /// Uses the terminal's 16 ANSI colors so the theme adapts to whatever
+    /// palette the user has configured in their terminal emulator (light variant).
+    pub fn ansi_light() -> Self {
+        Theme {
+            name: "ANSI Light".to_string(),
+            bg: ThemeColor::Reset,
+            bg_panel: ThemeColor::Ansi(7),    // light gray
+            bg_selected: ThemeColor::Ansi(4), // blue
+            fg: ThemeColor::Reset,
+            fg_secondary: ThemeColor::Ansi(8),       // dark gray
+            fg_muted: ThemeColor::Ansi(7),           // light gray
+            fg_selected: ThemeColor::Ansi(15),       // bright white
+            border: ThemeColor::Ansi(7),             // light gray
+            border_focused: ThemeColor::Ansi(4),     // blue
+            accent: ThemeColor::Ansi(4),             // blue
+            color_directory: ThemeColor::Ansi(4),    // blue
+            color_journal_date: ThemeColor::Ansi(2), // green
+            color_search_match: ThemeColor::Ansi(3), // yellow/amber
         }
     }
 }
@@ -763,8 +792,27 @@ mod tests {
     }
 
     #[test]
+    fn test_from_ansi_index() {
+        assert_eq!(
+            ThemeColor::from_string("ansi:4").unwrap(),
+            ThemeColor::Ansi(4)
+        );
+        assert_eq!(
+            ThemeColor::from_string("ansi:255").unwrap(),
+            ThemeColor::Ansi(255)
+        );
+    }
+
+    #[test]
+    fn test_from_reset() {
+        assert_eq!(ThemeColor::from_string("reset").unwrap(), ThemeColor::Reset);
+    }
+
+    #[test]
     fn test_all_builtin_themes_serialize() {
         let themes = vec![
+            Theme::ansi_dark(),
+            Theme::ansi_light(),
             Theme::gruvbox_dark(),
             Theme::gruvbox_light(),
             Theme::catppuccin_mocha(),
@@ -784,12 +832,25 @@ mod tests {
     }
 
     #[test]
-    fn test_ansi_theme() {
-        let theme = Theme::ansi();
-        assert_eq!(theme.name, "ANSI");
+    fn test_ansi_dark_theme() {
+        let theme = Theme::ansi_dark();
+        assert_eq!(theme.name, "ANSI Dark");
         assert_eq!(theme.bg, ThemeColor::Reset);
         assert_eq!(theme.fg, ThemeColor::Reset);
         assert_eq!(theme.bg_selected, ThemeColor::Ansi(4));
+        assert_eq!(theme.border_focused, ThemeColor::Ansi(6));
         assert_eq!(theme.color_directory, ThemeColor::Ansi(12));
+    }
+
+    #[test]
+    fn test_ansi_light_theme() {
+        let theme = Theme::ansi_light();
+        assert_eq!(theme.name, "ANSI Light");
+        assert_eq!(theme.bg, ThemeColor::Reset);
+        assert_eq!(theme.fg, ThemeColor::Reset);
+        assert_eq!(theme.bg_selected, ThemeColor::Ansi(4));
+        assert_eq!(theme.border_focused, ThemeColor::Ansi(4));
+        assert_eq!(theme.color_directory, ThemeColor::Ansi(4));
+        assert_eq!(theme.color_search_match, ThemeColor::Ansi(3));
     }
 }

--- a/tui/src/settings/themes.rs
+++ b/tui/src/settings/themes.rs
@@ -462,7 +462,7 @@ impl Theme {
         Theme {
             name: "ANSI".to_string(),
             bg: ThemeColor::Reset,
-            bg_panel: ThemeColor::Ansi(0),
+            bg_panel: ThemeColor::Reset,
             bg_selected: ThemeColor::Ansi(4), // blue
             fg: ThemeColor::Reset,
             fg_secondary: ThemeColor::Ansi(7),        // white

--- a/tui/src/settings/themes.rs
+++ b/tui/src/settings/themes.rs
@@ -43,10 +43,33 @@ impl ThemeColor {
     }
 
     /// Convert to the corresponding ratatui `Color`.
+    ///
+    /// ANSI indices 0–15 map to ratatui's named color variants so they emit
+    /// the standard SGR codes (30–37 / 90–97) the terminal's palette is keyed
+    /// to, rather than the 256-color `38;5;n` form which some terminals
+    /// remap inconsistently for the low 16 slots.
     pub fn to_ratatui(&self) -> Color {
         match self {
             ThemeColor::Rgb(r, g, b) => Color::Rgb(*r, *g, *b),
-            ThemeColor::Ansi(n) => Color::Indexed(*n),
+            ThemeColor::Ansi(n) => match n {
+                0 => Color::Black,
+                1 => Color::Red,
+                2 => Color::Green,
+                3 => Color::Yellow,
+                4 => Color::Blue,
+                5 => Color::Magenta,
+                6 => Color::Cyan,
+                7 => Color::Gray,
+                8 => Color::DarkGray,
+                9 => Color::LightRed,
+                10 => Color::LightGreen,
+                11 => Color::LightYellow,
+                12 => Color::LightBlue,
+                13 => Color::LightMagenta,
+                14 => Color::LightCyan,
+                15 => Color::White,
+                _ => Color::Indexed(*n),
+            },
             ThemeColor::Reset => Color::Reset,
         }
     }
@@ -431,10 +454,13 @@ impl Theme {
     }
 
     /// Uses the terminal's 16 ANSI colors so the theme adapts to whatever
-    /// palette the user has configured in their terminal emulator (dark variant).
-    pub fn ansi_dark() -> Self {
+    /// palette the user has configured in their terminal emulator. Works for
+    /// both light and dark terminal palettes because backgrounds and primary
+    /// foregrounds use `Reset` (the terminal's defaults) and accents are
+    /// chromatic ANSI slots whose hue is stable across palettes.
+    pub fn ansi() -> Self {
         Theme {
-            name: "ANSI Dark".to_string(),
+            name: "ANSI".to_string(),
             bg: ThemeColor::Reset,
             bg_panel: ThemeColor::Ansi(0),
             bg_selected: ThemeColor::Ansi(4), // blue
@@ -448,27 +474,6 @@ impl Theme {
             color_directory: ThemeColor::Ansi(12),    // bright blue
             color_journal_date: ThemeColor::Ansi(10), // bright green
             color_search_match: ThemeColor::Ansi(11), // bright yellow
-        }
-    }
-
-    /// Uses the terminal's 16 ANSI colors so the theme adapts to whatever
-    /// palette the user has configured in their terminal emulator (light variant).
-    pub fn ansi_light() -> Self {
-        Theme {
-            name: "ANSI Light".to_string(),
-            bg: ThemeColor::Reset,
-            bg_panel: ThemeColor::Ansi(7),    // light gray
-            bg_selected: ThemeColor::Ansi(4), // blue
-            fg: ThemeColor::Reset,
-            fg_secondary: ThemeColor::Ansi(8),       // dark gray
-            fg_muted: ThemeColor::Ansi(7),           // light gray
-            fg_selected: ThemeColor::Ansi(15),       // bright white
-            border: ThemeColor::Ansi(7),             // light gray
-            border_focused: ThemeColor::Ansi(4),     // blue
-            accent: ThemeColor::Ansi(4),             // blue
-            color_directory: ThemeColor::Ansi(4),    // blue
-            color_journal_date: ThemeColor::Ansi(2), // green
-            color_search_match: ThemeColor::Ansi(3), // yellow/amber
         }
     }
 }
@@ -593,7 +598,14 @@ mod tests {
 
     #[test]
     fn test_ansi_to_ratatui() {
-        assert_eq!(ThemeColor::Ansi(4).to_ratatui(), Color::Indexed(4));
+        // Low 16 ANSI indices map to named ratatui variants
+        assert_eq!(ThemeColor::Ansi(0).to_ratatui(), Color::Black);
+        assert_eq!(ThemeColor::Ansi(4).to_ratatui(), Color::Blue);
+        assert_eq!(ThemeColor::Ansi(7).to_ratatui(), Color::Gray);
+        assert_eq!(ThemeColor::Ansi(8).to_ratatui(), Color::DarkGray);
+        assert_eq!(ThemeColor::Ansi(15).to_ratatui(), Color::White);
+        // Indices >= 16 still use 256-color
+        assert_eq!(ThemeColor::Ansi(42).to_ratatui(), Color::Indexed(42));
         assert_eq!(ThemeColor::Reset.to_ratatui(), Color::Reset);
     }
 
@@ -811,8 +823,7 @@ mod tests {
     #[test]
     fn test_all_builtin_themes_serialize() {
         let themes = vec![
-            Theme::ansi_dark(),
-            Theme::ansi_light(),
+            Theme::ansi(),
             Theme::gruvbox_dark(),
             Theme::gruvbox_light(),
             Theme::catppuccin_mocha(),
@@ -832,25 +843,13 @@ mod tests {
     }
 
     #[test]
-    fn test_ansi_dark_theme() {
-        let theme = Theme::ansi_dark();
-        assert_eq!(theme.name, "ANSI Dark");
+    fn test_ansi_theme() {
+        let theme = Theme::ansi();
+        assert_eq!(theme.name, "ANSI");
         assert_eq!(theme.bg, ThemeColor::Reset);
         assert_eq!(theme.fg, ThemeColor::Reset);
         assert_eq!(theme.bg_selected, ThemeColor::Ansi(4));
         assert_eq!(theme.border_focused, ThemeColor::Ansi(6));
         assert_eq!(theme.color_directory, ThemeColor::Ansi(12));
-    }
-
-    #[test]
-    fn test_ansi_light_theme() {
-        let theme = Theme::ansi_light();
-        assert_eq!(theme.name, "ANSI Light");
-        assert_eq!(theme.bg, ThemeColor::Reset);
-        assert_eq!(theme.fg, ThemeColor::Reset);
-        assert_eq!(theme.bg_selected, ThemeColor::Ansi(4));
-        assert_eq!(theme.border_focused, ThemeColor::Ansi(4));
-        assert_eq!(theme.color_directory, ThemeColor::Ansi(4));
-        assert_eq!(theme.color_search_match, ThemeColor::Ansi(3));
     }
 }

--- a/tui/src/settings/themes.rs
+++ b/tui/src/settings/themes.rs
@@ -55,7 +55,6 @@ impl ThemeColor {
     /// - RGB: "rgb(255, 128, 0)"
     /// - 3-char hex: "#abc" (expanded to #aabbcc)
     /// - 6-char hex: "#aabbcc"
-    /// - ANSI index: "ansi:4"
     pub fn from_string(s: &str) -> Result<Self, String> {
         let s = s.trim();
 
@@ -63,12 +62,6 @@ impl ThemeColor {
             Self::from_hex(s)
         } else if s.starts_with("rgb(") && s.ends_with(')') {
             Self::from_rgb_string(s)
-        } else if s == "reset" {
-            Ok(ThemeColor::Reset)
-        } else if let Some(rest) = s.strip_prefix("ansi:") {
-            rest.parse::<u8>()
-                .map(ThemeColor::Ansi)
-                .map_err(|_| format!("Invalid ANSI color index: {}", rest))
         } else {
             Err(format!("Invalid color format: {}", s))
         }
@@ -431,20 +424,20 @@ impl Theme {
 
     /// Uses the terminal's 16 ANSI colors so the theme adapts to whatever
     /// palette the user has configured in their terminal emulator.
-    pub fn ansi_16() -> Self {
+    pub fn ansi() -> Self {
         Theme {
-            name: "ANSI 16".to_string(),
+            name: "ANSI".to_string(),
             bg: ThemeColor::Reset,
             bg_panel: ThemeColor::Ansi(0),    // black
             bg_selected: ThemeColor::Ansi(4), // blue
             fg: ThemeColor::Reset,
-            fg_secondary: ThemeColor::Ansi(7),  // white
-            fg_muted: ThemeColor::Ansi(8),      // bright black
-            fg_selected: ThemeColor::Ansi(15),  // bright white
-            border: ThemeColor::Ansi(8),        // bright black
-            border_focused: ThemeColor::Ansi(6), // cyan
-            accent: ThemeColor::Ansi(6),         // cyan
-            color_directory: ThemeColor::Ansi(12), // bright blue
+            fg_secondary: ThemeColor::Ansi(7),        // white
+            fg_muted: ThemeColor::Ansi(8),            // bright black
+            fg_selected: ThemeColor::Ansi(15),        // bright white
+            border: ThemeColor::Ansi(8),              // bright black
+            border_focused: ThemeColor::Ansi(6),      // cyan
+            accent: ThemeColor::Ansi(6),              // cyan
+            color_directory: ThemeColor::Ansi(12),    // bright blue
             color_journal_date: ThemeColor::Ansi(10), // bright green
             color_search_match: ThemeColor::Ansi(11), // bright yellow
         }
@@ -567,23 +560,6 @@ mod tests {
             ThemeColor::from_string("  #ff8800  ").unwrap(),
             ThemeColor::Rgb(255, 136, 0)
         );
-    }
-
-    #[test]
-    fn test_from_ansi_index() {
-        assert_eq!(
-            ThemeColor::from_string("ansi:4").unwrap(),
-            ThemeColor::Ansi(4)
-        );
-        assert_eq!(
-            ThemeColor::from_string("ansi:255").unwrap(),
-            ThemeColor::Ansi(255)
-        );
-    }
-
-    #[test]
-    fn test_from_reset() {
-        assert_eq!(ThemeColor::from_string("reset").unwrap(), ThemeColor::Reset);
     }
 
     #[test]
@@ -789,7 +765,6 @@ mod tests {
     #[test]
     fn test_all_builtin_themes_serialize() {
         let themes = vec![
-            Theme::ansi_16(),
             Theme::gruvbox_dark(),
             Theme::gruvbox_light(),
             Theme::catppuccin_mocha(),
@@ -806,5 +781,15 @@ mod tests {
             assert_eq!(theme.name, roundtrip.name);
             assert_eq!(theme.bg, roundtrip.bg);
         }
+    }
+
+    #[test]
+    fn test_ansi_theme() {
+        let theme = Theme::ansi();
+        assert_eq!(theme.name, "ANSI");
+        assert_eq!(theme.bg, ThemeColor::Reset);
+        assert_eq!(theme.fg, ThemeColor::Reset);
+        assert_eq!(theme.bg_selected, ThemeColor::Ansi(4));
+        assert_eq!(theme.color_directory, ThemeColor::Ansi(12));
     }
 }


### PR DESCRIPTION
ThemeColor becomes an enum (Rgb | Ansi | Reset) so colors can reference the user's terminal palette instead of hardcoded RGB. RGB path is unchanged; existing themes and custom TOML files are fully backward-compatible.

New "ANSI 16" theme maps bg/fg to Reset (true terminal defaults) and semantic roles to conventional ANSI indices. Custom themes can use "ansi:N" or "reset" in TOML color fields.

Example using my tomorrow night burns terminal theme in Ghostty:

<img width="1918" height="1056" alt="image" src="https://github.com/user-attachments/assets/1ffbf4f1-f618-4f70-b5d1-56b4e70eb48a" />

---

Can be modified depending on taste. Will add docs depending on the direction of how config would work. Will mark as draft until ready.

---
**TODO:**
- [x] Docs
- [x] More Tests
