### PR TITLE
feat(core): add link query operator (>/lk:) and search optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ docs/public/
 example/*/kimun.sqlite
 example/history/
 openspec/
+adr/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,3 +33,12 @@ The vertical `│` gutter the editor paints in place of the `>` sigils of a bloc
 
 **Code box**:
 The background rectangle the editor paints behind a code block (fenced or indented). Sized to the block's widest line and capped at the editor width — a box hugging the code, not a full-width band.
+
+### Search
+
+**Note link**:
+A note→note reference inside a note's body — either a `[[wikilink]]` or a markdown link resolving to a vault note. Attachments, images, and external URLs are *not* note links. Only note links participate in the **link filter**.
+
+**Link filter**:
+The search operator that selects notes by the note links they contain. "Notes that link to X" means notes whose body contains a note link **to** X — i.e. X's backlinks, not X's outgoing links. The target is matched by note name (extension optional, case-insensitive, `*` wildcards), across any folder unless a path is given to disambiguate.
+_Avoid_: backlink search (correct, but ambiguous about direction when read quickly)

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(core)* link query operator `>` / `lk:` (and exclusion `->` / `-lk:`) to filter notes by the notes they link to (backlinks); matches by note name with optional extension, path disambiguation, and `*` wildcards
+- *(core)* indexed `dest_name` column on the `links` table so the link filter matches by name with an index lookup instead of a full-table scan; bumps the cache version (existing vaults reindex on next launch)
+
+### Fixed
+
+- *(core)* search: multiple same-type filename/path filters (`@a @b`, `/x /y`) now AND together like the other operators and the documented precedence, instead of OR-ing
+- *(core)* search: combining a section filter with a section exclusion (`<work -<draft`) no longer returns zero results — breadcrumb exclusions now use a robust `NOT IN` subquery instead of an unreliable in-MATCH negation
+
 ## [0.2.13](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.12...kimun_core-v0.2.13) - 2026-05-29
 
 ### Fixed

--- a/core/src/db/mod.rs
+++ b/core/src/db/mod.rs
@@ -65,7 +65,7 @@ fn qualify_columns(prefix: &str, cols: &str) -> String {
 }
 
 use super::{
-    nfs::{NoteEntryData, PATH_SEPARATOR},
+    nfs::{with_note_extension, NoteEntryData, PATH_SEPARATOR},
     VaultPath,
 };
 
@@ -81,7 +81,11 @@ use super::{
 //      forces a clean reindex so the table is filled for existing vaults.
 // 0.5: BREADCRUMB_SEP changed from `>` to `\x1f`. Bump forces a clean
 //      reindex so stale rows with the old separator are rewritten.
-const VERSION: &str = "0.8";
+// 0.9: Added `dest_name` column + index to `links` (bare lowercased filename
+//      of each link destination) so the `>`/`lk:` link filter matches notes
+//      by name with an indexed lookup instead of a leading-`%` scan. Bump
+//      forces a clean reindex so the column is populated for existing vaults.
+const VERSION: &str = "0.9";
 pub(crate) const DB_FILE: &str = "kimun.sqlite";
 
 #[derive(Debug, Clone)]
@@ -258,7 +262,8 @@ async fn create_tables(pool: &SqlitePool) -> Result<(), DBError> {
     sqlx::query(
         "CREATE TABLE links (
             source TEXT,
-            destination TEXT
+            destination TEXT,
+            dest_name TEXT
         )",
     )
     .execute(&mut *tx)
@@ -267,6 +272,15 @@ async fn create_tables(pool: &SqlitePool) -> Result<(), DBError> {
     sqlx::query(
         "CREATE INDEX backlinks
             ON links(destination)",
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    // Backs the `>`/`lk:` link filter's name-anywhere match (folder-independent
+    // bare filename), so it never has to scan with a leading-`%` LIKE.
+    sqlx::query(
+        "CREATE INDEX links_by_dest_name
+            ON links(dest_name)",
     )
     .execute(&mut *tx)
     .await?;
@@ -303,14 +317,18 @@ async fn create_tables(pool: &SqlitePool) -> Result<(), DBError> {
     Ok(())
 }
 
+/// Joins the positive and negative conditions of one operator class. Positives
+/// AND together (each same-type term must match, matching the documented
+/// "all terms are ANDed" precedence and the `#`/`>`/`<` operators); negatives
+/// already AND.
 fn combine_conditions(positive: Vec<String>, negative: Vec<String>) -> Option<String> {
     match (positive.is_empty(), negative.is_empty()) {
         (true, true) => None,
-        (false, true) => Some(positive.join(" OR ")),
+        (false, true) => Some(positive.join(" AND ")),
         (true, false) => Some(negative.join(" AND ")),
         (false, false) => Some(format!(
-            "({}) AND ({})",
-            positive.join(" OR "),
+            "{} AND {}",
+            positive.join(" AND "),
             negative.join(" AND ")
         )),
     }
@@ -347,22 +365,6 @@ fn build_like_conditions(
     combine_conditions(positive_conditions, negative_conditions)
 }
 
-fn add_exclusion_conditions(
-    excluded_terms: &[String],
-    var_num: &mut usize,
-    exclusion_conditions: &mut Vec<String>,
-    params: &mut Vec<String>,
-) {
-    for excluded in excluded_terms {
-        exclusion_conditions.push(format!(
-            "notes.path NOT IN (SELECT DISTINCT notesContent.path FROM notesContent WHERE notesContent MATCH ?{})",
-            var_num
-        ));
-        params.push(fts4_quote(excluded));
-        *var_num += 1;
-    }
-}
-
 /// Base query for the search fan-out. Aliases `notes.path` to `path` so the
 /// shared `row_to_note_entry` mapper finds all `NOTE_COLUMNS` keys. First
 /// column is qualified to disambiguate the `notesContent`/`notes` join; the
@@ -383,11 +385,11 @@ fn build_search_sql_query_inner(search_terms: &SearchTerms) -> (String, Vec<Stri
     let mut params: Vec<String> = vec![];
     let mut queries: Vec<String> = vec![];
 
-    add_content_terms_query(search_terms, &mut var_num, &mut params, &mut queries);
-    add_breadcrumb_query(search_terms, &mut var_num, &mut params, &mut queries);
+    add_fts_query(search_terms, &mut var_num, &mut params, &mut queries);
     add_filename_query(search_terms, &mut var_num, &mut params, &mut queries);
     add_path_query(search_terms, &mut var_num, &mut params, &mut queries);
     add_labels_query(search_terms, &mut var_num, &mut params, &mut queries);
+    add_links_query(search_terms, &mut var_num, &mut params, &mut queries);
 
     if queries.is_empty() {
         debug!("No query provided");
@@ -396,102 +398,83 @@ fn build_search_sql_query_inner(search_terms: &SearchTerms) -> (String, Vec<Stri
     (queries.join(" INTERSECT "), params)
 }
 
-/// Free-text content terms: positive matches use FTS4 `MATCH`; exclusions use
-/// `NOT IN` subqueries because FTS4 doesn't support pure-negative queries.
-fn add_content_terms_query(
+/// Free-text + breadcrumb FTS branches. Content (whole-row) and breadcrumb
+/// (heading-path column) are *separate* INTERSECT branches: FTS4 allows only
+/// one `MATCH` per virtual table per SELECT, and its in-MATCH column filter
+/// (`breadcrumb:"x"`) is unreliable across builds, so the two cannot be folded
+/// into a single scan. Within each branch, the positive `MATCH` is ANDed with
+/// `NOT IN` subqueries for that field's exclusions (FTS4 has no reliable
+/// pure-negative / inline `-term`, so a subquery is used uniformly).
+fn add_fts_query(
     s: &SearchTerms,
     var_num: &mut usize,
     params: &mut Vec<String>,
     queries: &mut Vec<String>,
 ) {
-    if s.terms.is_empty() && s.excluded_terms.is_empty() {
-        return;
-    }
-    let mut exclusions = vec![];
-    add_exclusion_conditions(&s.excluded_terms, var_num, &mut exclusions, params);
-
-    if !s.terms.is_empty() {
-        let where_clause = if exclusions.is_empty() {
-            format!("notesContent MATCH ?{}", var_num)
-        } else {
-            format!(
-                "notesContent MATCH ?{} AND {}",
-                var_num,
-                exclusions.join(" AND ")
-            )
-        };
-        queries.push(format!("{} WHERE {}", search_base_sql(), where_clause));
-        let quoted: Vec<String> = s.terms.iter().map(|t| fts4_quote(t)).collect();
-        params.push(quoted.join(" "));
-        *var_num += 1;
-    } else if !exclusions.is_empty() {
-        // Pure exclusion: scan all notes, drop those matching the excluded terms.
-        queries.push(format!(
-            "{} WHERE {}",
-            search_base_sql(),
-            exclusions.join(" AND ")
-        ));
-    }
+    add_fts_field_query(
+        &s.terms,
+        &s.excluded_terms,
+        "notesContent",
+        fts4_quote,
+        var_num,
+        params,
+        queries,
+    );
+    add_fts_field_query(
+        &s.breadcrumb,
+        &s.excluded_breadcrumb,
+        "notesContent.breadcrumb",
+        fts4_quote,
+        var_num,
+        params,
+        queries,
+    );
 }
 
-/// Breadcrumb (heading-path) FTS column. Positive-only uses the column-scoped
-/// `MATCH`; mixed positive + exclusions inline column prefixes with `-`;
-/// exclusion-only uses `NOT IN`.
-fn add_breadcrumb_query(
-    s: &SearchTerms,
+/// Emits one FTS branch for a single field (`notesContent` for content,
+/// `notesContent.breadcrumb` for headings): a positive `MATCH` (all positive
+/// terms space-joined into one query) ANDed with one `NOT IN` subquery per
+/// excluded term. Pure-exclusion (no positives) drops the leading `MATCH`.
+fn add_fts_field_query(
+    positives: &[String],
+    excludeds: &[String],
+    match_target: &str,
+    quote: impl Fn(&str) -> String,
     var_num: &mut usize,
     params: &mut Vec<String>,
     queries: &mut Vec<String>,
 ) {
-    if s.breadcrumb.is_empty() && s.excluded_breadcrumb.is_empty() {
+    if positives.is_empty() && excludeds.is_empty() {
         return;
     }
-    if !s.breadcrumb.is_empty() {
-        if s.excluded_breadcrumb.is_empty() {
-            queries.push(format!(
-                "{} WHERE notesContent.breadcrumb MATCH ?{}",
-                search_base_sql(),
-                var_num
-            ));
-            params.push(
-                s.breadcrumb
-                    .iter()
-                    .map(|b| fts4_quote(b))
-                    .collect::<Vec<_>>()
-                    .join(" "),
-            );
-        } else {
-            let mut parts = Vec::with_capacity(s.breadcrumb.len() + s.excluded_breadcrumb.len());
-            for b in &s.breadcrumb {
-                parts.push(format!("breadcrumb: {}", fts4_quote(b)));
-            }
-            for b in &s.excluded_breadcrumb {
-                parts.push(format!("breadcrumb: -{}", fts4_quote(b)));
-            }
-            queries.push(format!(
-                "{} WHERE notesContent MATCH ?{}",
-                search_base_sql(),
-                var_num
-            ));
-            params.push(parts.join(" "));
-        }
+
+    let mut conditions: Vec<String> = vec![];
+
+    if !positives.is_empty() {
+        conditions.push(format!("{} MATCH ?{}", match_target, var_num));
+        params.push(
+            positives
+                .iter()
+                .map(|t| quote(t))
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
         *var_num += 1;
-        return;
     }
-    // Exclusion-only: NOT IN with column-prefixed term per excluded breadcrumb.
-    let mut exclusions = vec![];
-    for excluded in &s.excluded_breadcrumb {
-        exclusions.push(format!(
-            "notes.path NOT IN (SELECT DISTINCT notesContent.path FROM notesContent WHERE notesContent MATCH ?{})",
-            var_num
+
+    for term in excludeds {
+        conditions.push(format!(
+            "notes.path NOT IN (SELECT DISTINCT notesContent.path FROM notesContent WHERE {} MATCH ?{})",
+            match_target, var_num
         ));
-        params.push(format!("breadcrumb: {}", fts4_quote(excluded)));
+        params.push(quote(term));
         *var_num += 1;
     }
+
     queries.push(format!(
         "{} WHERE {}",
         search_base_sql(),
-        exclusions.join(" AND ")
+        conditions.join(" AND ")
     ));
 }
 
@@ -533,18 +516,64 @@ fn add_path_query(
     }
 }
 
-/// Notes-only base SELECT (no `notesContent` join) so label-only queries
-/// don't pay an FTS scan. Same columns as `SEARCH_BASE_SQL` so INTERSECT
-/// branches line up.
-static LABEL_BASE_SQL: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+/// Notes-only base SELECT (no `notesContent` join) so membership-style filters
+/// (labels, links) don't pay an FTS scan. No `DISTINCT`: `notes.path` is the
+/// primary key, so every notes-only branch already yields unique paths (and
+/// `INTERSECT` dedups across branches regardless). Same columns as
+/// `SEARCH_BASE_SQL` so INTERSECT branches line up.
+static NOTES_BASE_SQL: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
     format!(
-        "SELECT DISTINCT notes.path as path, {} FROM notes",
+        "SELECT notes.path as path, {} FROM notes",
         NOTE_COLUMNS_REST
     )
 });
 
-fn label_base_sql() -> &'static str {
-    &LABEL_BASE_SQL
+fn notes_base_sql() -> &'static str {
+    &NOTES_BASE_SQL
+}
+
+/// Fan-out shared by membership-style operators (labels, links): each positive
+/// term becomes its own INTERSECT branch (`notes.path IN (subquery)`); excluded
+/// terms are bundled into one notes-only SELECT chaining `NOT IN (subquery)` so
+/// the INTERSECT machinery still composes. `mk_subquery(term, var_num, params)`
+/// returns the inner `SELECT <col> FROM …` for one term (pushing its bind
+/// params and advancing `var_num`), or `None` to skip a degenerate term.
+fn add_membership_query<F>(
+    positives: &[String],
+    excludeds: &[String],
+    var_num: &mut usize,
+    params: &mut Vec<String>,
+    queries: &mut Vec<String>,
+    mk_subquery: F,
+) where
+    F: Fn(&str, &mut usize, &mut Vec<String>) -> Option<String>,
+{
+    for term in positives {
+        if let Some(sub) = mk_subquery(term, var_num, params) {
+            queries.push(format!(
+                "{} WHERE notes.path IN ({})",
+                notes_base_sql(),
+                sub
+            ));
+        }
+    }
+
+    if excludeds.is_empty() {
+        return;
+    }
+    let mut clauses = Vec::with_capacity(excludeds.len());
+    for term in excludeds {
+        if let Some(sub) = mk_subquery(term, var_num, params) {
+            clauses.push(format!("notes.path NOT IN ({})", sub));
+        }
+    }
+    if !clauses.is_empty() {
+        queries.push(format!(
+            "{} WHERE {}",
+            notes_base_sql(),
+            clauses.join(" AND ")
+        ));
+    }
 }
 
 fn add_labels_query(
@@ -553,37 +582,101 @@ fn add_labels_query(
     params: &mut Vec<String>,
     queries: &mut Vec<String>,
 ) {
-    // Each positive label is its own INTERSECT branch backed by the
-    // labels_by_name index via an IN subquery against `labels`.
-    for label in &s.labels {
-        let q = format!(
-            "{} WHERE notes.path IN (SELECT path FROM labels WHERE name = ?{})",
-            label_base_sql(),
-            var_num
-        );
-        queries.push(q);
-        params.push(label.clone());
-        *var_num += 1;
-    }
-
-    // Excluded labels: bundled into a single notes-only SELECT with a
-    // chain of NOT IN clauses (so the INTERSECT machinery still composes).
-    if !s.excluded_labels.is_empty() {
-        let mut clauses = Vec::with_capacity(s.excluded_labels.len());
-        for label in &s.excluded_labels {
-            clauses.push(format!(
-                "notes.path NOT IN (SELECT path FROM labels WHERE name = ?{})",
-                var_num
-            ));
-            params.push(label.clone());
+    // Each label is matched via the labels PK autoindex.
+    add_membership_query(
+        &s.labels,
+        &s.excluded_labels,
+        var_num,
+        params,
+        queries,
+        |label, var_num, params| {
+            let sub = format!("SELECT path FROM labels WHERE name = ?{}", var_num);
+            params.push(label.to_string());
             *var_num += 1;
-        }
-        queries.push(format!(
-            "{} WHERE {}",
-            label_base_sql(),
-            clauses.join(" AND ")
-        ));
+            Some(sub)
+        },
+    );
+}
+
+/// Builds the `SELECT source FROM links WHERE …` subquery for one link-filter
+/// target (`>`/`lk:`). Matching is by note name, extension optional,
+/// case-insensitive, with `*` wildcards.
+///
+/// A bare name matches a link in *any* folder via the indexed `dest_name`
+/// column (the folder-independent basename) — no leading-`%` scan. A slash in
+/// the target anchors it to a full path via indexed equality on `destination`
+/// (covering both the relative and absolute stored forms). Wildcards fall back
+/// to `LIKE`, but the pattern is prefix-anchored so the index can still help
+/// (e.g. `proj*`).
+///
+/// This is the name-anywhere counterpart to [`get_backlinks`], which matches a
+/// *specific* note by its exact full path or bare name. Both rely on the same
+/// stored-form invariant: link destinations are lowercased, carry the note
+/// extension, and are either a bare relative name or a relative/absolute path.
+/// Returns `None` for an empty target.
+fn link_subquery(target: &str, var_num: &mut usize, params: &mut Vec<String>) -> Option<String> {
+    let lowered = target.trim().to_lowercase();
+    // A leading separator only signals "absolute"; both stored forms are
+    // matched anyway, so strip it before normalizing.
+    let stripped = lowered.strip_prefix(PATH_SEPARATOR).unwrap_or(&lowered);
+    if stripped.is_empty() {
+        return None;
     }
+    let is_path_qualified = stripped.contains(PATH_SEPARATOR);
+    let has_wildcard = stripped.contains('*');
+    let name = with_note_extension(stripped);
+
+    let body = if has_wildcard {
+        // Escape LIKE metacharacters in the literal, then turn user `*` into
+        // the SQL `%` wildcard. Destinations never contain `*`, so this is safe.
+        let pattern = escape_like_pattern(&name).replace('*', "%");
+        params.push(pattern);
+        let body = if is_path_qualified {
+            format!(
+                "destination LIKE ?{n} ESCAPE '\\' OR destination LIKE ('/' || ?{n}) ESCAPE '\\'",
+                n = var_num
+            )
+        } else {
+            format!("dest_name LIKE ?{n} ESCAPE '\\'", n = var_num)
+        };
+        *var_num += 1;
+        body
+    } else if is_path_qualified {
+        // Indexed equality on the full path (relative or absolute stored form).
+        params.push(name);
+        let body = format!(
+            "destination = ?{n} OR destination = ('/' || ?{n})",
+            n = var_num
+        );
+        *var_num += 1;
+        body
+    } else {
+        // Indexed equality on the folder-independent basename.
+        params.push(name);
+        let body = format!("dest_name = ?{n}", n = var_num);
+        *var_num += 1;
+        body
+    };
+    Some(format!("SELECT source FROM links WHERE {body}"))
+}
+
+/// Link filter (`>` / `lk:`). Each positive target is its own INTERSECT branch
+/// (AND semantics, like labels); exclusions are bundled into a single
+/// notes-only SELECT chaining `NOT IN`.
+fn add_links_query(
+    s: &SearchTerms,
+    var_num: &mut usize,
+    params: &mut Vec<String>,
+    queries: &mut Vec<String>,
+) {
+    add_membership_query(
+        &s.links,
+        &s.excluded_links,
+        var_num,
+        params,
+        queries,
+        link_subquery,
+    );
 }
 
 /// Builds basePath conditions for path-style search terms. A trailing
@@ -868,6 +961,12 @@ pub async fn get_notes(
     rows.iter().map(row_to_note_entry).collect()
 }
 
+/// Backlinks of a *specific* note: notes whose body links to exactly this note,
+/// matched by its full path OR its bare filename (wikilinks stored without a
+/// path). This is intentionally narrower than the `>`/`lk:` search filter
+/// (see [`link_subquery`]), which matches a name in *any* folder; keep the two
+/// in step on the stored-form invariant they share (lowercased, `.md`-suffixed
+/// destinations, bare-relative or relative/absolute path).
 pub async fn get_backlinks(
     pool: &SqlitePool,
     path: &VaultPath,
@@ -1008,6 +1107,9 @@ struct ChunkRow {
 struct LinkRow {
     path_idx: usize,
     destination: String,
+    /// Bare lowercased filename of `destination` (folder-independent), indexed
+    /// to back the link filter's name-anywhere match. See `link_subquery`.
+    dest_name: String,
 }
 
 struct LabelRow {
@@ -1094,6 +1196,8 @@ impl NoteBatch {
                     self.links.push(LinkRow {
                         path_idx: idx,
                         destination: p.to_string(),
+                        // Already lowercased by VaultPathSlice; folder-independent.
+                        dest_name: p.get_name(),
                     });
                 }
                 LinkType::Hashtag => {
@@ -1238,16 +1342,18 @@ impl BulkInsertRow for ChunkRow {
 }
 
 impl BulkInsertRow for LinkRow {
-    const HEADER: &'static str = "INSERT INTO links (source, destination) VALUES ";
+    const HEADER: &'static str = "INSERT INTO links (source, destination, dest_name) VALUES ";
     const FOOTER: &'static str = "";
-    const COLS: usize = 2;
+    const COLS: usize = 3;
 
     fn bind_to<'q>(
         &'q self,
         q: sqlx::query::Query<'q, Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
         paths: &'q [String],
     ) -> sqlx::query::Query<'q, Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
-        q.bind(&paths[self.path_idx]).bind(&self.destination)
+        q.bind(&paths[self.path_idx])
+            .bind(&self.destination)
+            .bind(&self.dest_name)
     }
 }
 
@@ -1346,14 +1452,16 @@ pub async fn rename_note(
         .execute(&mut **tx)
         .await?;
 
-    sqlx::query("UPDATE links SET destination = ? WHERE destination = ?")
+    sqlx::query("UPDATE links SET destination = ?, dest_name = ? WHERE destination = ?")
         .bind(to.to_string())
+        .bind(&new_note_name)
         .bind(from.to_string())
         .execute(&mut **tx)
         .await?;
 
     // Update links that reference the note by filename only (wikilinks without path)
-    sqlx::query("UPDATE links SET destination = ? WHERE destination = ?")
+    sqlx::query("UPDATE links SET destination = ?, dest_name = ? WHERE destination = ?")
+        .bind(&new_note_name)
         .bind(&new_note_name)
         .bind(&old_note_name)
         .execute(&mut **tx)
@@ -1590,9 +1698,11 @@ mod tests {
     #[test]
     fn test_search_terms_query_multiple_paths() {
         let (sql, params) = build_search_sql_query("@file1 at:file2");
+        // Same-type operators AND together (consistent with #, >, <, and the
+        // documented "all terms are ANDed" precedence).
         assert_eq!(
             sql,
-            "SELECT DISTINCT notes.path as path, title, size, modified, hash, noteName FROM notesContent JOIN notes ON notesContent.path = notes.path WHERE notes.noteName LIKE ('%' || ?1 || '%') ESCAPE '\\' OR notes.noteName LIKE ('%' || ?2 || '%') ESCAPE '\\'"
+            "SELECT DISTINCT notes.path as path, title, size, modified, hash, noteName FROM notesContent JOIN notes ON notesContent.path = notes.path WHERE notes.noteName LIKE ('%' || ?1 || '%') ESCAPE '\\' AND notes.noteName LIKE ('%' || ?2 || '%') ESCAPE '\\'"
         );
         assert_eq!(params.len(), 2);
         assert_eq!(params[0], "file1");
@@ -1806,9 +1916,16 @@ mod tests {
     fn test_breadcrumb_exclusion_sql_generation() {
         let (sql, params) = build_search_sql_query("<project -<draft");
 
-        assert!(sql.contains("notesContent MATCH"));
-        assert_eq!(params.len(), 1);
-        assert_eq!(params[0], "breadcrumb: \"project\" breadcrumb: -\"draft\"");
+        // Positive breadcrumb is a column-scoped MATCH; the exclusion is a
+        // robust NOT IN subquery (not the old, broken inline `breadcrumb: -term`).
+        assert!(sql.contains("notesContent.breadcrumb MATCH ?1"));
+        assert!(sql.contains(
+            "notes.path NOT IN (SELECT DISTINCT notesContent.path FROM notesContent WHERE notesContent.breadcrumb MATCH ?2)"
+        ));
+        assert_eq!(
+            params,
+            vec!["\"project\"".to_string(), "\"draft\"".to_string()]
+        );
     }
 
     #[test]
@@ -2039,6 +2156,436 @@ mod tests {
             "two labels should INTERSECT: {}",
             sql
         );
+    }
+
+    #[test]
+    fn test_search_terms_query_links_only() {
+        let (sql, params) = build_search_sql_query(">projects");
+        assert_eq!(params, vec!["projects.md".to_string()]);
+        assert!(
+            sql.contains("FROM notes")
+                && sql.contains("SELECT source FROM links")
+                && sql.contains("notes.path IN"),
+            "links query should select sources from links: {}",
+            sql
+        );
+        // Bare name (no wildcard) matches the indexed dest_name column with
+        // plain equality — no leading-`%` scan.
+        assert!(
+            sql.contains("dest_name = ?1"),
+            "expected indexed dest_name equality: {}",
+            sql
+        );
+    }
+
+    #[test]
+    fn test_search_terms_query_links_long_form() {
+        let (_sql, params) = build_search_sql_query("lk:projects");
+        assert_eq!(params, vec!["projects.md".to_string()]);
+    }
+
+    #[test]
+    fn test_search_terms_query_links_path_qualified() {
+        let (sql, params) = build_search_sql_query(">work/projects");
+        assert_eq!(params, vec!["work/projects.md".to_string()]);
+        // Path-qualified anchors to the full path (relative or absolute) via
+        // indexed equality on `destination`, not the bare-name column.
+        assert!(
+            sql.contains("destination = ?1 OR destination = ('/' || ?1)"),
+            "expected path-anchored equality: {}",
+            sql
+        );
+        assert!(!sql.contains("dest_name"));
+    }
+
+    #[test]
+    fn test_search_terms_query_links_wildcard() {
+        let (sql, params) = build_search_sql_query(">proj*");
+        assert_eq!(params, vec!["proj%.md".to_string()]);
+        // Wildcard bare name uses a prefix LIKE on the indexed dest_name column.
+        assert!(
+            sql.contains("dest_name LIKE ?1 ESCAPE '\\'"),
+            "expected dest_name LIKE for wildcard: {}",
+            sql
+        );
+    }
+
+    #[test]
+    fn test_search_terms_query_links_extension_optional() {
+        let (_sql, params) = build_search_sql_query(">projects.md");
+        assert_eq!(params, vec!["projects.md".to_string()]);
+    }
+
+    #[test]
+    fn test_search_terms_query_excluded_links() {
+        let (sql, params) = build_search_sql_query("->draft");
+        assert_eq!(params, vec!["draft.md".to_string()]);
+        assert!(
+            sql.contains("notes.path NOT IN (SELECT source FROM links"),
+            "excluded links should use NOT IN: {}",
+            sql
+        );
+    }
+
+    #[test]
+    fn test_search_terms_query_two_links_intersect() {
+        let (sql, params) = build_search_sql_query(">a >b");
+        assert_eq!(params.len(), 2);
+        assert!(
+            sql.contains("INTERSECT"),
+            "two links should INTERSECT: {}",
+            sql
+        );
+    }
+
+    #[test]
+    fn test_search_terms_query_links_combined_with_operators() {
+        // Free-text term + link + label all compose via INTERSECT.
+        let (sql, params) = build_search_sql_query("meeting >spec #urgent");
+        assert_eq!(sql.matches("INTERSECT").count(), 2);
+        assert!(sql.contains("notesContent MATCH"));
+        assert!(sql.contains("SELECT source FROM links"));
+        assert!(sql.contains("FROM labels WHERE name"));
+        // Params follow the fan-out order: content term, label, then link.
+        assert_eq!(
+            params,
+            vec![
+                "\"meeting\"".to_string(),
+                "urgent".to_string(),
+                "spec.md".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn search_combining_links_with_other_operators() {
+        use crate::nfs::{NoteEntryData, VaultPath};
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("kimun.sqlite");
+        let db = super::VaultDB::new(&db_path).await.unwrap();
+        super::create_tables(db.pool()).await.unwrap();
+
+        let entries: Vec<(NoteEntryData, String)> = vec![
+            (
+                NoteEntryData {
+                    path: VaultPath::note_path_from("/work/a.md"),
+                    size: 10,
+                    modified_secs: 0,
+                },
+                "# Tasks\n[[spec]] meeting #urgent".to_string(),
+            ),
+            (
+                NoteEntryData {
+                    path: VaultPath::note_path_from("/b.md"),
+                    size: 10,
+                    modified_secs: 0,
+                },
+                "[[spec]] casual".to_string(),
+            ),
+            (
+                NoteEntryData {
+                    path: VaultPath::note_path_from("/c.md"),
+                    size: 10,
+                    modified_secs: 0,
+                },
+                "#urgent only, no link".to_string(),
+            ),
+        ];
+
+        let mut tx = db.pool().begin().await.unwrap();
+        super::insert_notes(&mut tx, &entries).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let paths = |results: &[(NoteEntryData, NoteContentData)]| {
+            let mut p: Vec<String> = results.iter().map(|(e, _)| e.path.to_string()).collect();
+            p.sort();
+            p
+        };
+
+        // link + free-text term.
+        let r = super::search_terms(db.pool(), ">spec meeting")
+            .await
+            .unwrap();
+        assert_eq!(paths(&r), vec!["/work/a.md".to_string()]);
+
+        // link + label.
+        let r = super::search_terms(db.pool(), ">spec #urgent")
+            .await
+            .unwrap();
+        assert_eq!(paths(&r), vec!["/work/a.md".to_string()]);
+
+        // link + excluded label.
+        let r = super::search_terms(db.pool(), ">spec -#urgent")
+            .await
+            .unwrap();
+        assert_eq!(paths(&r), vec!["/b.md".to_string()]);
+
+        // link + path filter.
+        let r = super::search_terms(db.pool(), ">spec /work").await.unwrap();
+        assert_eq!(paths(&r), vec!["/work/a.md".to_string()]);
+
+        // link + section (breadcrumb) filter.
+        let r = super::search_terms(db.pool(), ">spec <tasks")
+            .await
+            .unwrap();
+        assert_eq!(paths(&r), vec!["/work/a.md".to_string()]);
+
+        // link + filename filter.
+        let r = super::search_terms(db.pool(), ">spec @b").await.unwrap();
+        assert_eq!(paths(&r), vec!["/b.md".to_string()]);
+
+        // label without link still matches the non-linking note.
+        let r = super::search_terms(db.pool(), "#urgent -spec")
+            .await
+            .unwrap();
+        assert!(paths(&r).contains(&"/c.md".to_string()));
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn multiple_filename_terms_are_anded() {
+        use crate::nfs::{NoteEntryData, VaultPath};
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("kimun.sqlite");
+        let db = super::VaultDB::new(&db_path).await.unwrap();
+        super::create_tables(db.pool()).await.unwrap();
+
+        let entries: Vec<(NoteEntryData, String)> = vec![
+            (
+                NoteEntryData {
+                    path: VaultPath::note_path_from("/report-2024.md"),
+                    size: 10,
+                    modified_secs: 0,
+                },
+                "x".to_string(),
+            ),
+            (
+                NoteEntryData {
+                    path: VaultPath::note_path_from("/report-2023.md"),
+                    size: 10,
+                    modified_secs: 0,
+                },
+                "y".to_string(),
+            ),
+        ];
+        let mut tx = db.pool().begin().await.unwrap();
+        super::insert_notes(&mut tx, &entries).await.unwrap();
+        tx.commit().await.unwrap();
+
+        // @report @2024 must match ONLY the file containing both, not either.
+        let r = super::search_terms(db.pool(), "@report @2024")
+            .await
+            .unwrap();
+        let paths: Vec<String> = r.iter().map(|(e, _)| e.path.to_string()).collect();
+        assert_eq!(paths, vec!["/report-2024.md".to_string()]);
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn link_search_follows_rename() {
+        use crate::nfs::{NoteEntryData, VaultPath};
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("kimun.sqlite");
+        let db = super::VaultDB::new(&db_path).await.unwrap();
+        super::create_tables(db.pool()).await.unwrap();
+
+        let entry = NoteEntryData {
+            path: VaultPath::note_path_from("/a.md"),
+            size: 10,
+            modified_secs: 0,
+        };
+
+        let mut tx = db.pool().begin().await.unwrap();
+        super::insert_notes(&mut tx, &[(entry, "see [[target]]".to_string())])
+            .await
+            .unwrap();
+        // Rename the linked-to note; links (destination + dest_name) must follow.
+        super::rename_note(
+            &mut tx,
+            &VaultPath::note_path_from("/target.md"),
+            &VaultPath::note_path_from("/renamed.md"),
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        let r = super::search_terms(db.pool(), ">renamed").await.unwrap();
+        let paths: Vec<String> = r.iter().map(|(e, _)| e.path.to_string()).collect();
+        assert_eq!(paths, vec!["/a.md".to_string()]);
+
+        // The old name no longer matches.
+        let r = super::search_terms(db.pool(), ">target").await.unwrap();
+        assert!(r.is_empty());
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn search_by_link_returns_linking_notes() {
+        use crate::nfs::{NoteEntryData, VaultPath};
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("kimun.sqlite");
+        let db = super::VaultDB::new(&db_path).await.unwrap();
+        super::create_tables(db.pool()).await.unwrap();
+
+        let entries: Vec<(NoteEntryData, String)> = vec![
+            (
+                NoteEntryData {
+                    path: VaultPath::note_path_from("/index.md"),
+                    size: 10,
+                    modified_secs: 0,
+                },
+                "links [[projects]] and [[work/spec]]".to_string(),
+            ),
+            (
+                NoteEntryData {
+                    path: VaultPath::note_path_from("/b.md"),
+                    size: 10,
+                    modified_secs: 0,
+                },
+                "see [[projects]]".to_string(),
+            ),
+            (
+                NoteEntryData {
+                    path: VaultPath::note_path_from("/c.md"),
+                    size: 10,
+                    modified_secs: 0,
+                },
+                "no links here".to_string(),
+            ),
+        ];
+
+        let mut tx = db.pool().begin().await.unwrap();
+        super::insert_notes(&mut tx, &entries).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let paths = |results: &[(NoteEntryData, NoteContentData)]| {
+            let mut p: Vec<String> = results.iter().map(|(e, _)| e.path.to_string()).collect();
+            p.sort();
+            p
+        };
+
+        // Notes that link to "projects".
+        let r = super::search_terms(db.pool(), ">projects").await.unwrap();
+        assert_eq!(
+            paths(&r),
+            vec!["/b.md".to_string(), "/index.md".to_string()]
+        );
+
+        // Extension optional.
+        let r = super::search_terms(db.pool(), ">projects.md")
+            .await
+            .unwrap();
+        assert_eq!(
+            paths(&r),
+            vec!["/b.md".to_string(), "/index.md".to_string()]
+        );
+
+        // Bare name matches a note in a subfolder (name-anywhere).
+        let r = super::search_terms(db.pool(), ">spec").await.unwrap();
+        assert_eq!(paths(&r), vec!["/index.md".to_string()]);
+
+        // Path-qualified match.
+        let r = super::search_terms(db.pool(), ">work/spec").await.unwrap();
+        assert_eq!(paths(&r), vec!["/index.md".to_string()]);
+
+        // Wildcard.
+        let r = super::search_terms(db.pool(), ">proj*").await.unwrap();
+        assert_eq!(
+            paths(&r),
+            vec!["/b.md".to_string(), "/index.md".to_string()]
+        );
+
+        // Exclusion: all notes that do NOT link to projects (index and b both link it).
+        let r = super::search_terms(db.pool(), "->projects").await.unwrap();
+        assert_eq!(paths(&r), vec!["/c.md".to_string()]);
+
+        // Unknown target → no results.
+        let r = super::search_terms(db.pool(), ">nonexistent")
+            .await
+            .unwrap();
+        assert!(r.is_empty());
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fts_content_and_breadcrumb_combinations() {
+        use crate::nfs::{NoteEntryData, VaultPath};
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("kimun.sqlite");
+        let db = super::VaultDB::new(&db_path).await.unwrap();
+        super::create_tables(db.pool()).await.unwrap();
+
+        let mk = |p: &str, body: &str| {
+            (
+                NoteEntryData {
+                    path: VaultPath::note_path_from(p),
+                    size: 10,
+                    modified_secs: 0,
+                },
+                body.to_string(),
+            )
+        };
+        let entries = vec![
+            // "meeting" under a "Work" heading, also says "done".
+            mk("/a.md", "# Work\nmeeting notes, all done"),
+            // "meeting" but under "Personal", not "Work".
+            mk("/b.md", "# Personal\nmeeting with a friend"),
+            // "Work" heading but no "meeting".
+            mk("/c.md", "# Work\nbudget review"),
+        ];
+        let mut tx = db.pool().begin().await.unwrap();
+        super::insert_notes(&mut tx, &entries).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let paths = |r: &[(NoteEntryData, NoteContentData)]| {
+            let mut p: Vec<String> = r.iter().map(|(e, _)| e.path.to_string()).collect();
+            p.sort();
+            p
+        };
+
+        // content AND breadcrumb (both must hold).
+        let r = super::search_terms(db.pool(), "meeting <work")
+            .await
+            .unwrap();
+        assert_eq!(paths(&r), vec!["/a.md".to_string()]);
+
+        // two content terms AND (only /a.md has both "meeting" and "notes").
+        let r = super::search_terms(db.pool(), "meeting notes")
+            .await
+            .unwrap();
+        assert_eq!(paths(&r), vec!["/a.md".to_string()]);
+
+        // content positive + content exclusion.
+        let r = super::search_terms(db.pool(), "meeting -done")
+            .await
+            .unwrap();
+        assert_eq!(paths(&r), vec!["/b.md".to_string()]);
+
+        // breadcrumb positive + content exclusion.
+        let r = super::search_terms(db.pool(), "<work -budget")
+            .await
+            .unwrap();
+        assert_eq!(paths(&r), vec!["/a.md".to_string()]);
+
+        // breadcrumb positive + breadcrumb exclusion.
+        let r = super::search_terms(db.pool(), "<work -<personal")
+            .await
+            .unwrap();
+        assert_eq!(paths(&r), vec!["/a.md".to_string(), "/c.md".to_string()]);
+
+        // pure content exclusion (no positives anywhere).
+        let r = super::search_terms(db.pool(), "-meeting").await.unwrap();
+        assert_eq!(paths(&r), vec!["/c.md".to_string()]);
+
+        // pure breadcrumb exclusion.
+        let r = super::search_terms(db.pool(), "-<work").await.unwrap();
+        assert_eq!(paths(&r), vec!["/b.md".to_string()]);
+
+        db.close().await.unwrap();
     }
 
     #[tokio::test]

--- a/core/src/db/search_terms.rs
+++ b/core/src/db/search_terms.rs
@@ -18,6 +18,8 @@ enum ElementType {
     ExcludedPath,
     Label,
     ExcludedLabel,
+    Links,
+    ExcludedLinks,
 }
 
 struct QueryTermExtractor {
@@ -30,16 +32,18 @@ struct QueryTermExtractor {
 // Excluded variants must come before their positive counterparts so longer prefixes match first.
 type PrefixEntry = (&'static str, &'static str, fn() -> ElementType);
 
-fn prefix_table() -> [PrefixEntry; 8] {
+fn prefix_table() -> [PrefixEntry; 10] {
     [
         ("-in:", "-<", || ElementType::ExcludedIn),
         ("-at:", "-@", || ElementType::ExcludedAt),
         ("-pt:", "-/", || ElementType::ExcludedPath),
         ("-lb:", "-#", || ElementType::ExcludedLabel),
+        ("-lk:", "->", || ElementType::ExcludedLinks),
         ("in:", "<", || ElementType::In),
         ("at:", "@", || ElementType::At),
         ("pt:", "/", || ElementType::Path),
         ("lb:", "#", || ElementType::Label),
+        ("lk:", ">", || ElementType::Links),
     ]
 }
 
@@ -153,11 +157,13 @@ pub struct SearchTerms {
     pub filename: Vec<String>,
     pub path: Vec<String>,
     pub labels: Vec<String>,
+    pub links: Vec<String>,
     pub excluded_terms: Vec<String>,
     pub excluded_breadcrumb: Vec<String>,
     pub excluded_filename: Vec<String>,
     pub excluded_path: Vec<String>,
     pub excluded_labels: Vec<String>,
+    pub excluded_links: Vec<String>,
 }
 
 /// Maximum byte length of a query string accepted by [`SearchTerms::from_query_string`].
@@ -184,11 +190,13 @@ impl SearchTerms {
         let mut order_by = vec![];
         let mut path = vec![];
         let mut labels = vec![];
+        let mut links = vec![];
         let mut excluded_terms = vec![];
         let mut excluded_breadcrumb = vec![];
         let mut excluded_filename = vec![];
         let mut excluded_path = vec![];
         let mut excluded_labels = vec![];
+        let mut excluded_links = vec![];
         while !query.is_empty() {
             let qp = QueryTermExtractor::extract_and_consume(query);
             query = qp.remainder;
@@ -251,11 +259,23 @@ impl SearchTerms {
                         excluded_labels.push(n);
                     }
                 }
+                ElementType::Links => {
+                    if !qp.term.is_empty() {
+                        links.push(qp.term);
+                    }
+                }
+                ElementType::ExcludedLinks => {
+                    if !qp.term.is_empty() {
+                        excluded_links.push(qp.term);
+                    }
+                }
             }
         }
 
         dedup_preserving_order(&mut labels);
         dedup_preserving_order(&mut excluded_labels);
+        dedup_preserving_order(&mut links);
+        dedup_preserving_order(&mut excluded_links);
 
         Self {
             breadcrumb,
@@ -264,11 +284,13 @@ impl SearchTerms {
             terms,
             path,
             labels,
+            links,
             excluded_terms,
             excluded_breadcrumb,
             excluded_filename,
             excluded_path,
             excluded_labels,
+            excluded_links,
         }
     }
 }
@@ -427,6 +449,50 @@ mod tests {
     }
 
     #[test]
+    fn search_links_short() {
+        let s = SearchTerms::from_query_string(">projects");
+        assert_eq!(s.links, vec!["projects".to_string()]);
+        assert!(s.terms.is_empty());
+    }
+
+    #[test]
+    fn search_links_long() {
+        let s = SearchTerms::from_query_string("lk:projects");
+        assert_eq!(s.links, vec!["projects".to_string()]);
+    }
+
+    #[test]
+    fn search_links_with_extension_and_path() {
+        let s = SearchTerms::from_query_string(">work/projects.md");
+        assert_eq!(s.links, vec!["work/projects.md".to_string()]);
+    }
+
+    #[test]
+    fn search_links_excluded_short() {
+        let s = SearchTerms::from_query_string("->draft");
+        assert_eq!(s.excluded_links, vec!["draft".to_string()]);
+    }
+
+    #[test]
+    fn search_links_excluded_long() {
+        let s = SearchTerms::from_query_string("-lk:draft");
+        assert_eq!(s.excluded_links, vec!["draft".to_string()]);
+    }
+
+    #[test]
+    fn search_links_mixed_with_term() {
+        let s = SearchTerms::from_query_string("report >spec");
+        assert_eq!(s.terms, vec!["report".to_string()]);
+        assert_eq!(s.links, vec!["spec".to_string()]);
+    }
+
+    #[test]
+    fn search_links_quoted() {
+        let s = SearchTerms::from_query_string(">\"my note\"");
+        assert_eq!(s.links, vec!["my note".to_string()]);
+    }
+
+    #[test]
     fn search_label_short() {
         let s = SearchTerms::from_query_string("#important");
         assert_eq!(s.labels, vec!["important".to_string()]);
@@ -504,6 +570,7 @@ mod tests {
         // None of these bare prefixes should produce a term.
         for q in &[
             "<", "-", "-<", "in:", "at:", "pt:", "/", "@", "-/", "-@", "#", "-#", "lb:", "-lb:",
+            ">", "->", "lk:", "-lk:",
         ] {
             let s = SearchTerms::from_query_string(*q);
             assert!(s.terms.is_empty(), "{:?} produced terms: {:?}", q, s.terms);
@@ -555,6 +622,13 @@ mod tests {
                 "{:?} produced excluded_labels: {:?}",
                 q,
                 s.excluded_labels
+            );
+            assert!(s.links.is_empty(), "{:?} produced links: {:?}", q, s.links);
+            assert!(
+                s.excluded_links.is_empty(),
+                "{:?} produced excluded_links: {:?}",
+                q,
+                s.excluded_links
             );
         }
     }

--- a/core/src/nfs/mod.rs
+++ b/core/src/nfs/mod.rs
@@ -22,6 +22,20 @@ use super::utilities::path_to_string;
 pub const PATH_SEPARATOR: char = '/';
 const NOTE_EXTENSION: &str = ".md";
 
+/// Appends the note extension to `name` if it is not already present, without
+/// sanitizing the rest of the string. Unlike [`VaultPath::note_path_from`] this
+/// leaves wildcards and other non-path characters intact, so search patterns
+/// (e.g. `proj*`) keep their meaning. Use it only for building match patterns,
+/// never for constructing real vault paths.
+pub fn with_note_extension<S: AsRef<str>>(name: S) -> String {
+    let name = name.as_ref();
+    if name.ends_with(NOTE_EXTENSION) {
+        name.to_string()
+    } else {
+        format!("{name}{NOTE_EXTENSION}")
+    }
+}
+
 static RX_INCREMENT_SUFFIX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"_(?P<number>[0-9]+)$").unwrap());
 
@@ -726,12 +740,7 @@ impl VaultPath {
     /// E.g. `/projects/rust-notes` → `/projects/rust-notes.md`
     /// If the path already ends with the extension, returns it unchanged.
     pub fn to_string_with_ext(&self) -> String {
-        let s = self.to_string();
-        if s.ends_with(NOTE_EXTENSION) {
-            s
-        } else {
-            format!("{}{}", s, NOTE_EXTENSION)
-        }
+        with_note_extension(self.to_string())
     }
 
     fn increment<S: AsRef<str>>(name: S) -> String {
@@ -1092,7 +1101,23 @@ pub(crate) fn get_file_walker<P: AsRef<Path>>(
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use super::save_attachment;
+    use super::{save_attachment, with_note_extension};
+
+    #[test]
+    fn with_note_extension_appends_when_missing() {
+        assert_eq!(with_note_extension("projects"), "projects.md");
+    }
+
+    #[test]
+    fn with_note_extension_keeps_when_present() {
+        assert_eq!(with_note_extension("projects.md"), "projects.md");
+    }
+
+    #[test]
+    fn with_note_extension_preserves_wildcards_and_path() {
+        // Unlike VaultPath, this does not sanitize `*` so search wildcards survive.
+        assert_eq!(with_note_extension("work/proj*"), "work/proj*.md");
+    }
 
     /// Returns true if the filesystem at `dir` is case-sensitive.
     /// Used to skip "no duplicate lowercase entry" assertions on macOS and other

--- a/docs/content/using-kimun/ai-mcp-server.md
+++ b/docs/content/using-kimun/ai-mcp-server.md
@@ -16,7 +16,7 @@ The MCP client spawns and manages the `kimun mcp` process automatically — you 
 | `create_note` | Create a new note (fails if it already exists) |
 | `append_note` | Append text to a note (creates it if absent) |
 | `show_note` | Return the full markdown content of a note |
-| `search_notes` | Search with `@filename`, `<heading`, `/path`, `-exclusion` operators |
+| `search_notes` | Search with `@filename`, `<heading`, `/path`, `#label`, `>note` (links-to / backlinks), `-exclusion` operators |
 | `list_notes` | List all notes, optionally filtered by path prefix |
 | `journal` | Append to today's (or a specific date's) journal entry |
 | `get_backlinks` | List notes that link to the given note |

--- a/docs/content/using-kimun/cli.md
+++ b/docs/content/using-kimun/cli.md
@@ -79,12 +79,15 @@ Searches support free text, filters, and operators:
 - **Free text:** Case-insensitive, diacritics ignored, `*` wildcard supported
 - **Filter by filename:** `@tasks` or `at:tasks`
 - **Filter by section:** `<personal` or `in:personal` (Markdown headers)
+- **Filter by path:** `/journal` or `pt:journal` (directory prefix)
 - **Filter by label (hashtag):** `#important` or `lb:important` — matches notes carrying that `#tag` in their body
+- **Filter by link:** `>projects` or `lk:projects` — notes that link to the note "projects" (its backlinks); name match, `.md` optional, `*` wildcards, `>dir/note` to disambiguate
 - **Exclusion:** `-` prefix leads, then the operator follows
   - Content: `meeting -cancelled`
   - Title: `-<draft` or `-in:draft`
   - Filename: `-@temp` or `-at:temp`
   - Label: `-#draft` or `-lb:draft`
+  - Link: `->draft` or `-lk:draft`
 
 For comprehensive search documentation, see the [Search](@/using-kimun/search.md) page.
 
@@ -102,6 +105,9 @@ kimun search "<personal kimun"
 
 # Find notes labelled #important but not #archived
 kimun search "#important -#archived"
+
+# Find notes that link to "projects"
+kimun search ">projects"
 
 # Combine with jq for advanced filtering
 kimun search "rust" --format json | jq '.notes[] | select(.metadata.tags[] == "rust")'

--- a/docs/content/using-kimun/search.md
+++ b/docs/content/using-kimun/search.md
@@ -82,6 +82,33 @@ pt:docs          → same (long form)
 
 Paths are matched as prefixes, so `/docs` matches both `/docs/readme.md` and `/docs/guides/tutorial.md`.
 
+### `>` or `lk:` — link filter
+
+Filter to notes that **link to** a given note (its backlinks). A note matches when its body contains a note link — a `[[wikilink]]` or a Markdown link to a vault note — pointing at the target:
+
+```
+>projects        → notes that link to the note "projects"
+lk:projects      → same (long form)
+>projects.md     → same (the .md extension is optional)
+```
+
+The target is matched by note name, case-insensitively. The match is by **note identity**, not substring: `>projects` matches links to `projects` but not to `projects-archive`.
+
+A bare name matches a linked note in **any** folder. Add a path to disambiguate notes that share a name:
+
+```
+>projects        → links to any note named "projects" (e.g. work/projects, personal/projects)
+>work/projects   → links to work/projects only
+```
+
+Wildcards work here too:
+
+```
+>proj*           → notes linking to any note whose name starts with "proj"
+```
+
+Only links to other notes count — links to attachments, images, and external URLs are ignored.
+
 ## Labels
 
 Labels are `#name` tokens written directly in your note body. When Kimün indexes a note, any word starting with `#` followed by one or more `[A-Za-z0-9_]` characters is recorded as a label for that note.
@@ -148,9 +175,10 @@ Use the `-` prefix to exclude terms from search results. The `-` always leads, t
 -@temp               → exclude notes with "temp" in the filename
 -/private            → exclude notes under a "private/" directory
 -#draft              → exclude notes labelled "draft"
+->draft              → exclude notes that link to "draft"
 ```
 
-Long forms work the same way: `-in:draft`, `-at:temp`, `-pt:private`, `-lb:draft`.
+Long forms work the same way: `-in:draft`, `-at:temp`, `-pt:private`, `-lb:draft`, `-lk:draft`.
 
 ### Exclusion-only searches
 
@@ -225,6 +253,9 @@ The simple but great note taking app!
 | `lb:review` | notes labelled "review" | label filter (long form) |
 | `#finance #q2` | notes with both "finance" and "q2" labels | combined label filters |
 | `#project -#draft` | notes labelled "project" but not "draft" | label inclusion + exclusion |
+| `>kimun` | notes that link to the note "kimun" | link filter (backlinks) |
+| `lk:kimun #project` | notes linking to "kimun" and labelled "project" | link + label |
+| `>spec ->draft` | notes linking to "spec" but not to "draft" | link inclusion + exclusion |
 
 ## Edge cases
 

--- a/skills/kimun-cli/SKILL.md
+++ b/skills/kimun-cli/SKILL.md
@@ -20,6 +20,7 @@ Kimün is a local-first, terminal notes app. Notes are plain Markdown files inde
 | Show note content | `kimun note show "path"` |
 | Search notes | `kimun search "query"` |
 | List notes | `kimun notes` |
+| List all labels | `kimun labels` |
 
 ## Writing Notes
 
@@ -92,7 +93,13 @@ kimu*          # starts with "kimu"
 | `@term` | `at:term` | filename contains term |
 | `<term` | `in:term` | Markdown section heading contains term |
 | `/term` | `pt:term` | note path (directory) contains term |
+| `#label` | `lb:label` | note carries that hashtag label (from `#label` in body) |
+| `>note` | `lk:note` | notes that link to `note` (its backlinks) |
 | `-term` | | exclude notes containing term |
+
+**Hashtag labels** — any `#name` token in a note body (letters/digits/underscore) is indexed as a label and is case-insensitive. Hashtags inside frontmatter, code spans, fenced blocks, HTML, link bodies, and wikilinks are NOT indexed. Multiple `#` filters AND together.
+
+**Link filter** — `>note` (or `lk:note`) matches notes that link to `note`. Matched by note name (`.md` optional, case-insensitive); a bare name matches a linked note in any folder, `>dir/note` disambiguates, and `*` wildcards work (`>proj*`). Only links to other notes count, not attachments or URLs.
 
 **Exclusion composes with all operators — `-` leads, then the operator:**
 
@@ -101,6 +108,8 @@ kimu*          # starts with "kimu"
 -@temp               # exclude notes with "temp" in filename
 -<draft              # exclude notes with "draft" in any section title
 -/private            # exclude notes under a "private/" path
+-#archived           # exclude notes carrying #archived label
+->draft              # exclude notes that link to "draft"
 ```
 
 **Combining filters** (all terms are ANDed):
@@ -111,7 +120,76 @@ meeting -cancelled           # "meeting" but not "cancelled"
 @2024 -<draft                # files from 2024, no "draft" section title
 /journal <tasks -done        # in journal/, "tasks" section, excluding "done"
 <personal kimun              # "kimun" under a "Personal" section
+>spec #urgent                # links to "spec" and labelled "urgent"
+>kimun ->draft               # links to "kimun" but not to "draft"
+#important -#archived        # notes carrying #important but not #archived
+meeting #important           # "meeting" in notes also carrying #important
 ```
+
+## Listing Labels
+
+`kimun labels` enumerates every distinct hashtag label in the vault with note counts. Three formats:
+
+```sh
+kimun labels                  # text: `name (N notes)` per line, alphabetical
+kimun labels --format paths   # bare label names, one per line (pipeable)
+kimun labels --format json    # JSON: { workspace, total, labels: [{name, note_count}] }
+```
+
+### When to reach for it
+
+- **Map the vault's topical landscape** before answering "what does the user write about?" — `kimun labels` is the cheapest taxonomy survey available.
+- **Discover orphan/typo labels** — single-use labels often reveal a typo (`#imporant` vs `#important`) or a rarely-touched topic worth pruning.
+- **Drive label-based agentic browsing** — pick a label, then `kimun search "#label" --format paths | kimun note show` to read every note under it.
+- **Build per-label digests / per-topic dashboards** programmatically.
+
+### JSON schema
+
+```json
+{
+  "workspace": "personal",
+  "total": 12,
+  "labels": [
+    { "name": "idea",    "note_count": 5 },
+    { "name": "reading", "note_count": 4 }
+  ]
+}
+```
+
+### Effective patterns
+
+```sh
+# Top 10 most-used labels (most signal-rich topics first)
+kimun labels --format json | jq -r '.labels | sort_by(-.note_count) | .[:10][] | "\(.note_count)\t\(.name)"'
+
+# Single-use labels (candidate orphans / typos)
+kimun labels --format json | jq -r '.labels[] | select(.note_count == 1) | .name'
+
+# Read every note carrying a label
+kimun search "#systems" --format paths | kimun note show
+
+# Cross-tabulate two labels (AND)
+kimun search "#api #perf" --format paths
+
+# Label minus another label (e.g. open ideas)
+kimun search "#idea -#done" --format paths
+
+# Per-label index file
+kimun labels --format paths | while read l; do
+  echo "## $l"
+  kimun search "#$l" --format paths | sed 's/^/- /'
+  echo
+done > vault-by-label.md
+
+# Quick "what do I work on?" summary
+kimun labels --format json | jq -r '.labels[] | "\(.note_count)\t\(.name)"' | sort -rn | head
+```
+
+### Notes
+
+- Label names are stored lowercase. `#Foo` and `#foo` collapse into one entry.
+- A label is only counted once per note even if the hashtag appears many times.
+- Counts reflect what's INDEXED — hashtags inside frontmatter, code, HTML, link bodies, and wikilinks are excluded.
 
 ## Reading Notes
 
@@ -168,11 +246,18 @@ kimun journal show
 
 # Chain: search → read all matching notes
 kimun search "meeting notes" --format paths | kimun note show
+
+# Survey topics before working: list labels, pick the relevant one, read all notes
+kimun labels
+kimun search "#api" --format paths | kimun note show
+
+# Pre-tag a captured note in one shot (labels live in body, not frontmatter)
+echo "Quick thought about caching. #idea #perf" | kimun note append "inbox/cache-thoughts"
 ```
 
 ## Common Mistakes
 
 - **`create` on an existing note** — it fails. Use `append` when you're not sure if the note exists.
 - **No stdin from a live terminal** — piping works (`echo "x" | kimun journal`); passing no content from an interactive terminal produces an empty write.
-- **Relative vs absolute paths** — if a `quick_note_path` is set in `config.toml`, relative paths are resolved against it. Prefix with `/` to always target the vault root explicitly.
+- **Relative vs absolute paths** — if a `quick_note_path` is set in `kimun_config.toml`, relative paths are resolved against it. Prefix with `/` to always target the vault root explicitly.
 - **`kimun journal show` — `--format paths` is not supported**; use `text` or `json`.

--- a/tui/src/cli/commands/mcp/mod.rs
+++ b/tui/src/cli/commands/mcp/mod.rs
@@ -191,7 +191,7 @@ impl KimunHandler {
     }
 
     #[tool(
-        description = "Search notes by query. Supports @filename, <heading (or in:heading), /path prefix, #label (or lb:label) for hashtag-derived labels, and - prefix for exclusion (e.g. -term, -#label, -lb:label, -@filename, -<heading, -/path). Hashtag labels (#label) are extracted from note body text only — hashtags inside YAML/TOML frontmatter, fenced code blocks, inline code, HTML, markdown link bodies, and [[wikilinks]] are not indexed. Label names are ASCII [A-Za-z0-9_]+ and matched case-insensitively. Long queries are truncated at 8 KB."
+        description = "Search notes by query. Supports @filename, <heading (or in:heading), /path prefix, #label (or lb:label) for hashtag-derived labels, >note (or lk:note) for notes that link to the given note (its backlinks), and - prefix for exclusion (e.g. -term, -#label, -lb:label, -@filename, -<heading, -/path, ->note, -lk:note). The link filter matches by note name (the .md extension is optional, case-insensitive); a bare name matches a linked note in any folder, a path like >dir/note disambiguates, and * wildcards are allowed (>proj*). Hashtag labels (#label) are extracted from note body text only — hashtags inside YAML/TOML frontmatter, fenced code blocks, inline code, HTML, markdown link bodies, and [[wikilinks]] are not indexed. Label names are ASCII [A-Za-z0-9_]+ and matched case-insensitively. Long queries are truncated at 8 KB."
     )]
     async fn search_notes(
         &self,


### PR DESCRIPTION
Adds a search operator to filter notes by the notes they link to (backlinks): >note / lk:note, with exclusion ->note / -lk:note. Matches by note name (extension optional, case-insensitive), with * wildcards and optional path disambiguation (>dir/note); name-anywhere matching is backed by a new indexed dest_name column on the links table (cache VERSION 0.8 -> 0.9, reindex on next launch).

Also:
- search: multiple same-type filename/path filters (@a @b, /x /y) now AND together like the other operators and the documented precedence, instead of OR-ing.
- search: combining a section filter with a section exclusion (<work -<draft) no longer returns zero results; breadcrumb exclusions use a robust NOT IN subquery instead of an unreliable in-MATCH negation.
- refactor: shared add_membership_query for labels+links, unified FTS field handling, notes-only base SELECT drops redundant DISTINCT.
- docs/skills/MCP: document the new operator; reconcile the two diverged kimun-cli skills.