### PR TITLE
fix: apply bold/italic to nested links and wikilinks

### DIFF
--- a/tui/src/components/text_editor/markdown/mod.rs
+++ b/tui/src/components/text_editor/markdown/mod.rs
@@ -134,6 +134,12 @@ pub struct ParsedLine {
     /// Per-char element index, 1-based (0 = no element). Enables O(1) `elem_at`.
     /// Stored as `u16`; supports up to 65535 elements per line.
     elem_index: Vec<u16>,
+    /// Per-char text-modifier mask (`MOD_BOLD` / `MOD_ITALIC` / `MOD_STRIKE`)
+    /// OR-ed from *every* element covering the char, so an inner Link/WikiLink
+    /// nested inside `**…**` / `*…*` still renders bold/italic. `elem_index`
+    /// only tracks the innermost element (for fg/underline), which would
+    /// otherwise drop the outer emphasis modifiers.
+    modifier_mask: Vec<u8>,
     /// Char offset where the list-item sigil (indent + marker + space) ends on
     /// this line, or `None` if this line is not the first line of a list item.
     list_sigil_end: Option<usize>,
@@ -190,6 +196,12 @@ impl ParsedLine {
     /// Whether `pos` falls inside any tracked element. O(1) via precomputed `elem_vis`.
     pub fn in_any_element(&self, pos: usize) -> bool {
         self.elem_vis.get(pos).copied().unwrap_or(false)
+    }
+
+    /// Combined emphasis-modifier mask (`MOD_*`) for the char at `pos`, OR-ed
+    /// across all covering elements. `0` outside any emphasis element.
+    pub(super) fn modifiers_at(&self, pos: usize) -> u8 {
+        self.modifier_mask.get(pos).copied().unwrap_or(0)
     }
 
     /// Returns the char offset of the first *content* char inside a heading element
@@ -344,6 +356,36 @@ pub(super) fn list_marker_len(s: &str) -> Option<usize> {
     } else {
         None
     }
+}
+
+/// Per-char emphasis-modifier bits, OR-ed across nested elements.
+pub(super) const MOD_BOLD: u8 = 1 << 0;
+pub(super) const MOD_ITALIC: u8 = 1 << 1;
+pub(super) const MOD_STRIKE: u8 = 1 << 2;
+
+/// Emphasis bit contributed by an element kind, or `0` for non-emphasis kinds.
+pub(super) fn modifier_bit(kind: ElementKind) -> u8 {
+    match kind {
+        ElementKind::Bold => MOD_BOLD,
+        ElementKind::Italic => MOD_ITALIC,
+        ElementKind::Strikethrough => MOD_STRIKE,
+        _ => 0,
+    }
+}
+
+/// Translates a `MOD_*` mask into ratatui [`Modifier`] flags.
+pub(super) fn mask_to_modifier(mask: u8) -> Modifier {
+    let mut m = Modifier::empty();
+    if mask & MOD_BOLD != 0 {
+        m |= Modifier::BOLD;
+    }
+    if mask & MOD_ITALIC != 0 {
+        m |= Modifier::ITALIC;
+    }
+    if mask & MOD_STRIKE != 0 {
+        m |= Modifier::CROSSED_OUT;
+    }
+    m
 }
 
 pub(super) fn span_style(kind: Option<ElementKind>, is_sigil_region: bool, theme: &Theme) -> Style {
@@ -944,6 +986,62 @@ mod tests {
             text(&s),
             "# bold",
             "leading * must not leak into heading sigil"
+        );
+    }
+
+    #[test]
+    fn bold_wikilink_is_bold() {
+        let line = "**[[Topic]]**";
+        let s = MarkdownSpanner::render(line, line, 0, None, true, false, 40, &t());
+        assert_eq!(text(&s), "Topic");
+        assert!(
+            s.iter()
+                .any(|sp| sp.style.add_modifier.contains(Modifier::BOLD)
+                    && sp.content.contains("Topic")),
+            "wikilink wrapped in ** must render bold"
+        );
+    }
+
+    #[test]
+    fn italic_link_is_italic() {
+        let line = "*[text](http://x)*";
+        let s = MarkdownSpanner::render(line, line, 0, None, true, false, 40, &t());
+        assert_eq!(text(&s), "text");
+        assert!(
+            s.iter()
+                .any(|sp| sp.style.add_modifier.contains(Modifier::ITALIC)
+                    && sp.content.contains("text")),
+            "link wrapped in * must render italic"
+        );
+    }
+
+    #[test]
+    fn bold_italic_wikilink_is_bold_and_italic() {
+        let line = "***[[Topic]]***";
+        let s = MarkdownSpanner::render(line, line, 0, None, true, false, 40, &t());
+        assert_eq!(text(&s), "Topic");
+        assert!(
+            s.iter().any(|sp| {
+                sp.content.contains("Topic")
+                    && sp.style.add_modifier.contains(Modifier::BOLD)
+                    && sp.style.add_modifier.contains(Modifier::ITALIC)
+            }),
+            "wikilink in *** *** must render both bold and italic"
+        );
+    }
+
+    #[test]
+    fn bold_italic_plain_text() {
+        let line = "***text***";
+        let s = MarkdownSpanner::render(line, line, 0, None, true, false, 40, &t());
+        assert_eq!(text(&s), "text");
+        assert!(
+            s.iter().any(|sp| {
+                sp.content.contains("text")
+                    && sp.style.add_modifier.contains(Modifier::BOLD)
+                    && sp.style.add_modifier.contains(Modifier::ITALIC)
+            }),
+            "*** *** must render both bold and italic"
         );
     }
 

--- a/tui/src/components/text_editor/markdown/parsed_buffer.rs
+++ b/tui/src/components/text_editor/markdown/parsed_buffer.rs
@@ -545,12 +545,18 @@ impl ParsedBuffer {
             let total = line.chars().count();
             let mut elem_vis = vec![false; total];
             let mut elem_index = vec![0u16; total];
+            // OR-ed emphasis mask: unlike elem_index (innermost wins), every
+            // covering Bold/Italic/Strikethrough contributes, so a Link or
+            // WikiLink nested in `**…**` / `*…*` keeps the outer emphasis.
+            let mut modifier_mask = vec![0u8; total];
             for (i, e) in els.iter().enumerate() {
                 let tag = (i + 1) as u16;
+                let bit = super::modifier_bit(e.kind);
                 for pos in e.start_char..e.end_char {
                     if pos < total {
                         elem_vis[pos] = true;
                         elem_index[pos] = tag;
+                        modifier_mask[pos] |= bit;
                     }
                 }
             }
@@ -573,6 +579,7 @@ impl ParsedBuffer {
                 content_vis: cv,
                 elem_vis,
                 elem_index,
+                modifier_mask,
                 list_sigil_end: list_sigil_end[row],
                 image_placeholders,
                 blockquote_depth,
@@ -693,6 +700,7 @@ impl ParsedBuffer {
                 content_vis: vec![true; total],
                 elem_vis: vec![false; total],
                 elem_index: vec![0; total],
+                modifier_mask: vec![0; total],
                 list_sigil_end: None,
                 image_placeholders: Vec::new(),
                 blockquote_depth: None,

--- a/tui/src/components/text_editor/markdown/spanner.rs
+++ b/tui/src/components/text_editor/markdown/spanner.rs
@@ -11,7 +11,7 @@
 
 use super::{
     ElementKind, ParsedLine, blockquote_gutter, cluster_display_width, cluster_width_at,
-    span_style, tab_width_at,
+    mask_to_modifier, span_style, tab_width_at,
 };
 use crate::settings::themes::Theme;
 use ratatui::style::Style;
@@ -242,6 +242,7 @@ impl MarkdownSpanner {
         let mut seg_elem: Option<usize> = None;
         let mut seg_is_sigil = false;
         let mut seg_is_expanded = false;
+        let mut seg_mods: u8 = 0;
         // Tracks the current rendered visual column for tab-stop calculation.
         let mut visual_col = 0usize;
 
@@ -249,6 +250,7 @@ impl MarkdownSpanner {
                      seg_elem: Option<usize>,
                      seg_is_sigil: bool,
                      seg_is_expanded: bool,
+                     seg_mods: u8,
                      spans: &mut Vec<Span<'a>>| {
             if seg_str.is_empty() {
                 return;
@@ -257,7 +259,11 @@ impl MarkdownSpanner {
             let style = if seg_is_expanded {
                 Style::default().fg(theme.fg_muted.to_ratatui())
             } else {
+                // OR in emphasis modifiers from outer elements so a Link /
+                // WikiLink nested in `**…**` / `*…*` keeps the bold/italic the
+                // innermost-element style alone would drop.
                 span_style(seg_elem.map(|i| elements[i].kind), seg_is_sigil, theme)
+                    .add_modifier(mask_to_modifier(seg_mods))
             };
             spans.push(Span::styled(seg, style));
         };
@@ -297,6 +303,7 @@ impl MarkdownSpanner {
                         seg_elem,
                         seg_is_sigil,
                         seg_is_expanded,
+                        seg_mods,
                         &mut spans,
                     );
                     let style = span_style(Some(ElementKind::Image), false, theme);
@@ -305,6 +312,7 @@ impl MarkdownSpanner {
                     seg_elem = None;
                     seg_is_sigil = false;
                     seg_is_expanded = false;
+                    seg_mods = 0;
                 }
             }
 
@@ -330,31 +338,37 @@ impl MarkdownSpanner {
                     seg_elem,
                     seg_is_sigil,
                     seg_is_expanded,
+                    seg_mods,
                     &mut spans,
                 );
                 seg_elem = None;
                 seg_is_sigil = false;
                 seg_is_expanded = false;
+                seg_mods = 0;
                 continue;
             }
             let this_is_expanded = in_expanded_elem;
             let this_is_sigil = (in_heading_sigil || in_list_sigil || in_blockquote_sigil)
                 && !is_content
                 && !in_expanded_elem;
+            let this_mods = parsed.modifiers_at(pos);
             if this_elem != seg_elem
                 || this_is_sigil != seg_is_sigil
                 || this_is_expanded != seg_is_expanded
+                || this_mods != seg_mods
             {
                 flush(
                     &mut seg_str,
                     seg_elem,
                     seg_is_sigil,
                     seg_is_expanded,
+                    seg_mods,
                     &mut spans,
                 );
                 seg_elem = this_elem;
                 seg_is_sigil = this_is_sigil;
                 seg_is_expanded = this_is_expanded;
+                seg_mods = this_mods;
             }
             if cluster == "\t" {
                 let tw = tab_width_at(visual_col);
@@ -372,6 +386,7 @@ impl MarkdownSpanner {
             seg_elem,
             seg_is_sigil,
             seg_is_expanded,
+            seg_mods,
             &mut spans,
         );
 


### PR DESCRIPTION
A Link or WikiLink wrapped in ** ** or * * (e.g. **[[Topic]]** or *[text](url)*) rendered without the bold/italic emphasis. Each char tracked only its innermost element via elem_index, and span_style maps a single ElementKind to a style, so the inner Link/WikiLink style replaced the outer Bold/Italic entirely, dropping the modifier.

Add a per-char modifier_mask to ParsedLine, OR-ed across every covering element (Bold/Italic/Strikethrough). The renderer keeps the innermost element's fg/underline and OR-s the accumulated emphasis modifiers into the span style, so nested emphasis now composes.

Adds regression tests bold_wikilink_is_bold and italic_link_is_italic.