### PR TITLE
ci: run release-pr job even when release fails

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,6 +37,10 @@ jobs:
   release-plz-pr:
     name: Release-plz PR
     needs: release-plz-release
+    # Run even when the release job fails: a failed release must still produce
+    # the version-bump PR, otherwise the bump that fixes the release never gets
+    # proposed and every subsequent push fails the same way.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     concurrency:
       group: release-plz


### PR DESCRIPTION
A failed release job skipped release-plz-pr, so the version-bump PR that would fix the release was never created and every push to main failed the same way (kimun_server_client verified against the stale published kimun_core).