### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "kimun-notes"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arboard",
  "async-trait",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "kimun_server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "kimun_server_client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "kimun_core",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/nico2sh/kimun/compare/kimun_server_client-v0.1.0...kimun_server_client-v0.1.1) - 2026-07-15
+
+### Other
+
+- quickstart
+
 ## [0.1.0](https://github.com/nico2sh/kimun/releases/tag/kimun_server_client-v0.1.0) - 2026-07-15
 
 ### Added

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun_server_client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Client for the Kimün RAG server — capability probing, note sync, and hash-diff reconciliation"
 license = "MIT"

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/nico2sh/kimun/compare/kimun_server-v0.1.0...kimun_server-v0.2.0) - 2026-07-15
+
+### Added
+
+- server logs in the ui
+
 ## [0.1.0](https://github.com/nico2sh/kimun/releases/tag/kimun_server-v0.1.0) - 2026-07-15
 
 ### Added

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun_server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [[bin]]

--- a/tui/CHANGELOG.md
+++ b/tui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.20.0...kimun-notes-v0.20.1) - 2026-07-15
+
+### Other
+
+- quickstart
+
 ## [0.20.0](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.19.5...kimun-notes-v0.20.0) - 2026-07-15
 
 ### Added

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun-notes"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 description = "A terminal-based notes application"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 kimun_core = { path = "../core", version = "0.2.28" }
-kimun_server_client = { path = "../client", version = "0.1.0" }
+kimun_server_client = { path = "../client", version = "0.1.1" }
 
 clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6.5"


### PR DESCRIPTION



## 🤖 New release

* `kimun_server_client`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `kimun-notes`: 0.20.0 -> 0.20.1 (✓ API compatible changes)
* `kimun_server`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `kimun_server` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AppState.log_buffer in /tmp/.tmpFNd9nP/kimun/server/src/server_state.rs:23
  field AppState.startup_error in /tmp/.tmpFNd9nP/kimun/server/src/server_state.rs:28
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `kimun_server_client`

<blockquote>

## [0.1.1](https://github.com/nico2sh/kimun/compare/kimun_server_client-v0.1.0...kimun_server_client-v0.1.1) - 2026-07-15

### Other

- quickstart
</blockquote>

## `kimun-notes`

<blockquote>

## [0.20.1](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.20.0...kimun-notes-v0.20.1) - 2026-07-15

### Other

- quickstart
</blockquote>

## `kimun_server`

<blockquote>

## [0.2.0](https://github.com/nico2sh/kimun/compare/kimun_server-v0.1.0...kimun_server-v0.2.0) - 2026-07-15

### Added

- server logs in the ui
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).