### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "kimun-notes"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "arboard",
  "async-trait",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "kimun_core"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "chrono",
  "criterion",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "kimun_server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "kimun_server_client"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "kimun_core",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/nico2sh/kimun/compare/kimun_server_client-v0.1.1...kimun_server_client-v0.2.0) - 2026-07-20
+
+### Added
+
+- add history parameter to RagClient::ask()
+
+### Fixed
+
+- fmt
+
+### Other
+
+- *(ask)* make citation↔source pairing an explicit ordinal contract
+- *(ask)* cleanup batch — dedupe, derive, test gaps
+
 ## [0.1.1](https://github.com/nico2sh/kimun/compare/kimun_server_client-v0.1.0...kimun_server_client-v0.1.1) - 2026-07-15
 
 ### Other

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun_server_client"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 description = "Client for the Kimün RAG server — capability probing, note sync, and hash-diff reconciliation"
 license = "MIT"
@@ -8,7 +8,7 @@ readme = "../README.md"
 repository = "https://github.com/nico2sh/kimun"
 
 [dependencies]
-kimun_core = { path = "../core", version = "0.2.28" }
+kimun_core = { path = "../core", version = "0.2.29" }
 serde = { workspace = true }
 serde_json = "1.0"
 tokio = { workspace = true }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.29](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.28...kimun_core-v0.2.29) - 2026-07-20
+
+### Added
+
+- *(ask)* add note_name_from_title core helper and ask::save module
+
+### Fixed
+
+- *(core,tui)* move Ask source-reader heading fallback into core scan
+
+### Other
+
+- apply the five confirmed review findings
+- *(core)* split nfs mod.rs into vault_path and backup
+- *(ask)* cleanup batch — dedupe, derive, test gaps
+
 ## [0.2.28](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.27...kimun_core-v0.2.28) - 2026-07-15
 
 ### Added

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun_core"
-version = "0.2.28"
+version = "0.2.29"
 authors = ["Nico Hormazábal <mail@nico2sh.com>"]
 edition = "2021"
 description = "Core library for the Kimün notes application"

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/nico2sh/kimun/compare/kimun_server-v0.3.0...kimun_server-v0.4.0) - 2026-07-20
+
+### Added
+
+- *(server)* thread conversation history through /api/answer
+- *(server)* thread conversation history through the LLM client
+- *(server)* add citation numbering to RAG prompt
+
+### Fixed
+
+- fmt
+- *(server)* anchor terse follow-ups to the assistant's last message
+- *(ask)* resolve 7 holistic-review findings in the Ask workspace
+- *(ask)* condition RAG retrieval on conversation for terse follow-ups
+- *(ask)* correct Ask conversation, provenance, reader wrap, and empty-title prompt
+
+### Other
+
+- Merge pull request #172 from nico2sh/ask-rag
+- Merge branch 'worktree-arch-strong-batch' into ask-rag
+- *(ask)* make citation↔source pairing an explicit ordinal contract
+- *(ask)* cleanup batch — dedupe, derive, test gaps
+
 ## [0.3.0](https://github.com/nico2sh/kimun/compare/kimun_server-v0.2.0...kimun_server-v0.3.0) - 2026-07-16
 
 ### Added

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun_server"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [[bin]]

--- a/tui/CHANGELOG.md
+++ b/tui/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.20.1...kimun-notes-v0.21.0) - 2026-07-20
+
+### Added
+
+- *(tui)* add list focus to SearchList and wire FIND verbs
+- *(ask)* distinct turns and hidden emphasis sigils in answers
+- *(ask)* converge Sources drawer with FIND's preview and rows
+- *(ask)* render answer markdown, thread scrolling, and cleaner sources
+- *(tui)* integrate Ask workspace — rail entry, drawer view, editor wiring, keys
+- *(tui)* add Ask SourcesPanel drawer view with reader face
+- *(tui)* wire ThreadPanel render, input, and ask task
+- *(tui)* editor-area third arm for Ask + AskData events
+- *(ask)* add note_name_from_title core helper and ask::save module
+- *(tui)* add ask domain Thread/Turn/AskSource
+- *(tui)* implement ask::citations module with scan, strip, link_sources
+- add history parameter to RagClient::ask()
+
+### Fixed
+
+- fmt
+- *(tui)* synchronous row-set seam for static Sources list
+- *(tui)* box the Sources filter field like FIND's query searchbox
+- *(tui)* wire Sources redraw through tx and defer cross-turn citation focus
+- *(tui)* strip CR from preview lines on CRLF notes
+- *(ask)* resolve 7 holistic-review findings in the Ask workspace
+- *(ask)* don't italicize intraword underscores in answers
+- *(ask)* no dangling separator on bare-date source rows
+- *(ask)* drive SEM rail entry from live RAG status
+- *(ask)* correct Ask conversation, provenance, reader wrap, and empty-title prompt
+- *(tui)* keep "OpenRagAnswer" parseable as a legacy ActionShortcuts alias
+- *(core,tui)* move Ask source-reader heading fallback into core scan
+- *(tui/ask)* citations module scanner and rewrite logic
+
+### Other
+
+- Merge branch 'worktree-arch-strong-batch' into ask-rag
+- *(tui)* delegate Ask answer block identity to the editor markdown model
+- *(tui)* extract shared yank-to-clipboard helper
+- *(tui)* rebuild Sources view on the shared list engine
+- *(tui)* unify preview pane's needle/range render families
+- *(tui)* use ? operator in begin_turn client guard
+- *(ask)* make citation↔source pairing an explicit ordinal contract
+- *(ask)* single-owner Ask workspace panels
+- *(ask)* cleanup batch — dedupe, derive, test gaps
+- *(tui)* delete the old Ask (RAG) modal overlay
+- *(ask)* confirm Sources footer covers all sources, not just cited ones
+
 ## [0.20.1](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.20.0...kimun-notes-v0.20.1) - 2026-07-15
 
 ### Other

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun-notes"
-version = "0.20.1"
+version = "0.21.0"
 edition = "2024"
 description = "A terminal-based notes application"
 license = "MIT"
@@ -16,8 +16,8 @@ name = "kimun_notes"
 path = "src/lib.rs"
 
 [dependencies]
-kimun_core = { path = "../core", version = "0.2.28" }
-kimun_server_client = { path = "../client", version = "0.1.1" }
+kimun_core = { path = "../core", version = "0.2.29" }
+kimun_server_client = { path = "../client", version = "0.2.0" }
 
 clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6.5"


### PR DESCRIPTION



## 🤖 New release

* `kimun_core`: 0.2.28 -> 0.2.29 (✓ API compatible changes)
* `kimun_server_client`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `kimun-notes`: 0.20.1 -> 0.21.0 (⚠ API breaking changes)
* `kimun_server`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `kimun_server_client` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ChunkResult.ordinal in /tmp/.tmpNYDQPU/kimun/client/src/dto.rs:71
  field ChunkResult.ordinal in /tmp/.tmpNYDQPU/kimun/client/src/dto.rs:71
  field QueryRequest.history in /tmp/.tmpNYDQPU/kimun/client/src/dto.rs:49

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  kimun_server_client::RagClient::ask takes 2 parameters in /tmp/.tmpiPnybO/kimun_server_client/src/lib.rs:258, but now takes 3 parameters in /tmp/.tmpNYDQPU/kimun/client/src/lib.rs:259
```

### ⚠ `kimun-notes` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CreateNoteDialog.content in /tmp/.tmpNYDQPU/kimun/tui/src/components/dialogs/create_note_dialog.rs:26
  field CreateNoteDialog.content in /tmp/.tmpNYDQPU/kimun/tui/src/components/dialogs/create_note_dialog.rs:26
  field Icons.question_prompt in /tmp/.tmpNYDQPU/kimun/tui/src/settings/icons.rs:17

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type AppEvent no longer derives Clone, in /tmp/.tmpNYDQPU/kimun/tui/src/components/events.rs:32

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant DrawerView::Tags 3 -> 4 in /tmp/.tmpNYDQPU/kimun/tui/src/components/drawer.rs:29
  variant DrawerView::Links 4 -> 5 in /tmp/.tmpNYDQPU/kimun/tui/src/components/drawer.rs:30
  variant DrawerView::Outline 5 -> 6 in /tmp/.tmpNYDQPU/kimun/tui/src/components/drawer.rs:31
  variant DrawerView::Config 6 -> 7 in /tmp/.tmpNYDQPU/kimun/tui/src/components/drawer.rs:32
  variant OverlayKind::Dialog 4 -> 3 in /tmp/.tmpNYDQPU/kimun/tui/src/components/overlay.rs:21

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant LeaderAction:AskFocus in /tmp/.tmpNYDQPU/kimun/tui/src/keys/leader.rs:61
  variant LeaderAction:AskNew in /tmp/.tmpNYDQPU/kimun/tui/src/keys/leader.rs:62
  variant LeaderAction:AskCopy in /tmp/.tmpNYDQPU/kimun/tui/src/keys/leader.rs:63
  variant LeaderAction:AskSave in /tmp/.tmpNYDQPU/kimun/tui/src/keys/leader.rs:64
  variant LeaderAction:AskRegenerate in /tmp/.tmpNYDQPU/kimun/tui/src/keys/leader.rs:65
  variant LeaderAction:AskSource in /tmp/.tmpNYDQPU/kimun/tui/src/keys/leader.rs:66
  variant AppEvent:Ask in /tmp/.tmpNYDQPU/kimun/tui/src/components/events.rs:148
  variant KeyReaction:ListVerb in /tmp/.tmpNYDQPU/kimun/tui/src/components/search_list/mod.rs:74
  variant DrawerView:Ask in /tmp/.tmpNYDQPU/kimun/tui/src/components/drawer.rs:28
  variant ActionShortcuts:OpenAsk in /tmp/.tmpNYDQPU/kimun/tui/src/keys/action_shortcuts.rs:53
  variant FileOp:ShowCreateWithContent in /tmp/.tmpNYDQPU/kimun/tui/src/components/events.rs:235

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant OverlayData::RagAnswerReady, previously in file /tmp/.tmpiPnybO/kimun-notes/src/components/events.rs:244
  variant ActionShortcuts::OpenRagAnswer, previously in file /tmp/.tmpiPnybO/kimun-notes/src/keys/action_shortcuts.rs:52
  variant OverlayKind::RagAnswer, previously in file /tmp/.tmpiPnybO/kimun-notes/src/components/overlay.rs:21

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  TextEditorComponent::vim_space_leads, previously in file /tmp/.tmpiPnybO/kimun-notes/src/components/text_editor/mod.rs:777
  BackendState::vim_sync_mouse_selection, previously in file /tmp/.tmpiPnybO/kimun-notes/src/components/text_editor/backend.rs:203
  BackendState::vim_space_leads, previously in file /tmp/.tmpiPnybO/kimun-notes/src/components/text_editor/backend.rs:216
  BackendState::vim_is_charwise_visual, previously in file /tmp/.tmpiPnybO/kimun-notes/src/components/text_editor/backend.rs:225
  BackendState::vim_reset_to_normal, previously in file /tmp/.tmpiPnybO/kimun-notes/src/components/text_editor/backend.rs:233
  BackendState::vim_pending_hint, previously in file /tmp/.tmpiPnybO/kimun-notes/src/components/text_editor/backend.rs:261

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  kimun_notes::components::dialogs::create_note_dialog::CreateNoteDialog::new takes 2 parameters in /tmp/.tmpiPnybO/kimun-notes/src/components/dialogs/create_note_dialog.rs:26, but now takes 3 parameters in /tmp/.tmpNYDQPU/kimun/tui/src/components/dialogs/create_note_dialog.rs:30
  kimun_notes::components::dialogs::CreateNoteDialog::new takes 2 parameters in /tmp/.tmpiPnybO/kimun-notes/src/components/dialogs/create_note_dialog.rs:26, but now takes 3 parameters in /tmp/.tmpNYDQPU/kimun/tui/src/components/dialogs/create_note_dialog.rs:30
  kimun_notes::components::drawer::DrawerHost::new takes 6 parameters in /tmp/.tmpiPnybO/kimun-notes/src/components/drawer.rs:64, but now takes 8 parameters in /tmp/.tmpNYDQPU/kimun/tui/src/components/drawer.rs:73
  kimun_notes::components::dialogs::ActiveDialog::create_note takes 2 parameters in /tmp/.tmpiPnybO/kimun-notes/src/components/dialogs/mod.rs:125, but now takes 3 parameters in /tmp/.tmpNYDQPU/kimun/tui/src/components/dialogs/mod.rs:125

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod kimun_notes::components::rag_answer, previously in file /tmp/.tmpiPnybO/kimun-notes/src/components/rag_answer.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct kimun_notes::rag::RagSource, previously in file /tmp/.tmpiPnybO/kimun-notes/src/rag/mod.rs:51
  struct kimun_notes::components::rag_answer::RagAnswerOverlay, previously in file /tmp/.tmpiPnybO/kimun-notes/src/components/rag_answer.rs:40
  struct kimun_notes::rag::RagAnswer, previously in file /tmp/.tmpiPnybO/kimun-notes/src/rag/mod.rs:44
```

### ⚠ `kimun_server` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AnswerRequest.history in /tmp/.tmpNYDQPU/kimun/server/src/handlers.rs:87
  field ChunkResult.ordinal in /tmp/.tmpNYDQPU/kimun/server/src/handlers.rs:124

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  kimun_server::KimunRag::answer takes 3 parameters in /tmp/release-plz-kimun_server-pmpqF0/worktree/target/package/kimun_server-0.3.0/src/lib.rs:410, but now takes 4 parameters in /tmp/.tmpNYDQPU/kimun/server/src/lib.rs:411

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  LLMClient::ask now takes 3 instead of 2 parameters, in file /tmp/.tmpNYDQPU/kimun/server/src/llmclients/mod.rs:22
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `kimun_core`

<blockquote>

## [0.2.29](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.28...kimun_core-v0.2.29) - 2026-07-20

### Added

- *(ask)* add note_name_from_title core helper and ask::save module

### Fixed

- *(core,tui)* move Ask source-reader heading fallback into core scan

### Other

- apply the five confirmed review findings
- *(core)* split nfs mod.rs into vault_path and backup
- *(ask)* cleanup batch — dedupe, derive, test gaps
</blockquote>

## `kimun_server_client`

<blockquote>

## [0.2.0](https://github.com/nico2sh/kimun/compare/kimun_server_client-v0.1.1...kimun_server_client-v0.2.0) - 2026-07-20

### Added

- add history parameter to RagClient::ask()

### Fixed

- fmt

### Other

- *(ask)* make citation↔source pairing an explicit ordinal contract
- *(ask)* cleanup batch — dedupe, derive, test gaps
</blockquote>

## `kimun-notes`

<blockquote>

## [0.21.0](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.20.1...kimun-notes-v0.21.0) - 2026-07-20

### Added

- *(tui)* add list focus to SearchList and wire FIND verbs
- *(ask)* distinct turns and hidden emphasis sigils in answers
- *(ask)* converge Sources drawer with FIND's preview and rows
- *(ask)* render answer markdown, thread scrolling, and cleaner sources
- *(tui)* integrate Ask workspace — rail entry, drawer view, editor wiring, keys
- *(tui)* add Ask SourcesPanel drawer view with reader face
- *(tui)* wire ThreadPanel render, input, and ask task
- *(tui)* editor-area third arm for Ask + AskData events
- *(ask)* add note_name_from_title core helper and ask::save module
- *(tui)* add ask domain Thread/Turn/AskSource
- *(tui)* implement ask::citations module with scan, strip, link_sources
- add history parameter to RagClient::ask()

### Fixed

- fmt
- *(tui)* synchronous row-set seam for static Sources list
- *(tui)* box the Sources filter field like FIND's query searchbox
- *(tui)* wire Sources redraw through tx and defer cross-turn citation focus
- *(tui)* strip CR from preview lines on CRLF notes
- *(ask)* resolve 7 holistic-review findings in the Ask workspace
- *(ask)* don't italicize intraword underscores in answers
- *(ask)* no dangling separator on bare-date source rows
- *(ask)* drive SEM rail entry from live RAG status
- *(ask)* correct Ask conversation, provenance, reader wrap, and empty-title prompt
- *(tui)* keep "OpenRagAnswer" parseable as a legacy ActionShortcuts alias
- *(core,tui)* move Ask source-reader heading fallback into core scan
- *(tui/ask)* citations module scanner and rewrite logic

### Other

- Merge branch 'worktree-arch-strong-batch' into ask-rag
- *(tui)* delegate Ask answer block identity to the editor markdown model
- *(tui)* extract shared yank-to-clipboard helper
- *(tui)* rebuild Sources view on the shared list engine
- *(tui)* unify preview pane's needle/range render families
- *(tui)* use ? operator in begin_turn client guard
- *(ask)* make citation↔source pairing an explicit ordinal contract
- *(ask)* single-owner Ask workspace panels
- *(ask)* cleanup batch — dedupe, derive, test gaps
- *(tui)* delete the old Ask (RAG) modal overlay
- *(ask)* confirm Sources footer covers all sources, not just cited ones
</blockquote>

## `kimun_server`

<blockquote>

## [0.4.0](https://github.com/nico2sh/kimun/compare/kimun_server-v0.3.0...kimun_server-v0.4.0) - 2026-07-20

### Added

- *(server)* thread conversation history through /api/answer
- *(server)* thread conversation history through the LLM client
- *(server)* add citation numbering to RAG prompt

### Fixed

- fmt
- *(server)* anchor terse follow-ups to the assistant's last message
- *(ask)* resolve 7 holistic-review findings in the Ask workspace
- *(ask)* condition RAG retrieval on conversation for terse follow-ups
- *(ask)* correct Ask conversation, provenance, reader wrap, and empty-title prompt

### Other

- Merge pull request #172 from nico2sh/ask-rag
- Merge branch 'worktree-arch-strong-batch' into ask-rag
- *(ask)* make citation↔source pairing an explicit ordinal contract
- *(ask)* cleanup batch — dedupe, derive, test gaps
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).