### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "kimun-notes"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "arboard",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "kimun_core"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "chrono",
  "criterion",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "kimun_server_client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "kimun_core",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/nico2sh/kimun/compare/kimun_server_client-v0.2.0...kimun_server_client-v0.2.1) - 2026-08-01
+
+### Other
+
+- updated the following local packages: kimun_core
+
 ## [0.2.0](https://github.com/nico2sh/kimun/compare/kimun_server_client-v0.1.1...kimun_server_client-v0.2.0) - 2026-07-20
 
 ### Added

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun_server_client"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Client for the Kimün RAG server — capability probing, note sync, and hash-diff reconciliation"
 license = "MIT"
@@ -8,7 +8,7 @@ readme = "../README.md"
 repository = "https://github.com/nico2sh/kimun"
 
 [dependencies]
-kimun_core = { path = "../core", version = "0.2.29" }
+kimun_core = { path = "../core", version = "0.2.30" }
 serde = { workspace = true }
 serde_json = "1.0"
 tokio = { workspace = true }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.30](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.29...kimun_core-v0.2.30) - 2026-08-01
+
+### Fixed
+
+- fmt
+- position panic
+- line breaks are not changed on save
+
 ## [0.2.29](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.28...kimun_core-v0.2.29) - 2026-07-20
 
 ### Added

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun_core"
-version = "0.2.29"
+version = "0.2.30"
 authors = ["Nico Hormazábal <mail@nico2sh.com>"]
 edition = "2021"
 description = "Core library for the Kimün notes application"

--- a/tui/CHANGELOG.md
+++ b/tui/CHANGELOG.md
@@ -7,6 +7,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.21.0...kimun-notes-v0.22.0) - 2026-08-01
+
+### Added
+
+- undo coalescing
+- up and down arrows move on visual lines
+- find and replace
+- flash actions on key combos
+
+### Fixed
+
+- home path exansion test
+- fmt
+- image rendering correct
+- overlay fix
+- tui and engine consistent rendering
+- proper click mapper on links
+- rendering
+- find match scroll
+- blockquote final fix
+- blockquote unblock
+- record numers correctly the changes
+- range performance
+- fmt
+- position panic
+- bugs
+- no string vectors
+- clippy and benches on CI
+- selection bug on search
+- correctness on bump
+- proper rendering full text on replace
+- highlight logical text
+- visual fixes
+- highlights correct on rendered links
+- highlight changes on replace
+- bugfixes
+- paste images in vim mode
+- fixed copy paste on vim mode using ctrl C V X
+
+### Other
+
+- unified tab width definition
+- context update
+- document overlay improvement opportunity
+- document decision on no translator mapping
+- position_at_cell
+- reset regression
+- incremental parse on block
+- removed bench
+- line delta on edits
+- newline decouple
+- new benches
+- micro otimizations
+- async render
+- removed ?Send requirement
+- test for single undo for wrapping words
+- removed reference old code
+- key table
+- ratatui-textarea out from build
+- shim removed on text editor
+- vim connection
+- wired in the view
+- markdown tie in
+- tests on ropetext
+- performance on keystroke
+- no textarea
+- snapshot
+- highlighting code
+- find bar
+- consolidate undo
+- input ownership
+
 ## [0.21.0](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.20.1...kimun-notes-v0.21.0) - 2026-07-20
 
 ### Added

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun-notes"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 description = "A terminal-based notes application"
 license = "MIT"
@@ -16,8 +16,8 @@ name = "kimun_notes"
 path = "src/lib.rs"
 
 [dependencies]
-kimun_core = { path = "../core", version = "0.2.29" }
-kimun_server_client = { path = "../client", version = "0.2.0" }
+kimun_core = { path = "../core", version = "0.2.30" }
+kimun_server_client = { path = "../client", version = "0.2.1" }
 # Path-only, no version: nothing for release-plz to rewrite (see release-plz.toml).
 ropetext = { path = "../ropetext" }
 


### PR DESCRIPTION



## 🤖 New release

* `kimun_core`: 0.2.29 -> 0.2.30 (✓ API compatible changes)
* `kimun-notes`: 0.21.0 -> 0.22.0 (⚠ API breaking changes)
* `kimun_server_client`: 0.2.0 -> 0.2.1

### ⚠ `kimun-notes` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TextareaBackend.typing in /tmp/.tmpW1X6li/kimun/tui/src/components/text_editor/backend.rs:93
  field Theme.color_replace_preview in /tmp/.tmpW1X6li/kimun/tui/src/settings/themes/mod.rs:310
  field EditorSnapshot.text in /tmp/.tmpW1X6li/kimun/tui/src/components/text_editor/snapshot.rs:20
  field WidenerMetrics.full_downstream_flip in /tmp/.tmpW1X6li/kimun/tui/src/components/text_editor/widener_metrics.rs:92
  field Snapshot.full_downstream_flip in /tmp/.tmpW1X6li/kimun/tui/src/components/text_editor/widener_metrics.rs:167

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ActionShortcuts:YankRow in /tmp/.tmpW1X6li/kimun/tui/src/keys/action_shortcuts.rs:51
  variant ActionShortcuts:ReplaceInBuffer in /tmp/.tmpW1X6li/kimun/tui/src/keys/action_shortcuts.rs:67
  variant BailReason:DownstreamFlip in /tmp/.tmpW1X6li/kimun/tui/src/components/text_editor/widener_metrics.rs:66
  variant EditorBackendSetting:Plain in /tmp/.tmpW1X6li/kimun/tui/src/settings/mod.rs:69
  variant KeyReaction:Yank in /tmp/.tmpW1X6li/kimun/tui/src/components/search_list/mod.rs:82

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant EditorBackendSetting::Textarea, previously in file /tmp/.tmpjrmWPC/kimun-notes/src/settings/mod.rs:62

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function kimun_notes::components::text_editor::autocomplete_glue::row_char_col_to_byte, previously in file /tmp/.tmpjrmWPC/kimun-notes/src/components/text_editor/autocomplete_glue.rs:37
  function kimun_notes::components::text_editor::autocomplete_glue::byte_to_row_char_col, previously in file /tmp/.tmpjrmWPC/kimun-notes/src/components/text_editor/autocomplete_glue.rs:18

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  TextEditorComponent::lines, previously in file /tmp/.tmpjrmWPC/kimun-notes/src/components/text_editor/mod.rs:632

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  kimun_notes::components::drawer_views::OutlinePanel::new takes 2 parameters in /tmp/.tmpjrmWPC/kimun-notes/src/components/drawer_views.rs:575, but now takes 3 parameters in /tmp/.tmpW1X6li/kimun/tui/src/components/drawer_views.rs:591
  kimun_notes::components::text_editor::markdown::MarkdownSpanner::rendered_col_to_logical_with takes 6 parameters in /tmp/.tmpjrmWPC/kimun-notes/src/components/text_editor/markdown/spanner.rs:562, but now takes 7 parameters in /tmp/.tmpW1X6li/kimun/tui/src/components/text_editor/markdown/spanner.rs:659
  kimun_notes::components::semantic_search::SemanticPanel::new takes 3 parameters in /tmp/.tmpjrmWPC/kimun-notes/src/components/semantic_search.rs:143, but now takes 4 parameters in /tmp/.tmpW1X6li/kimun/tui/src/components/semantic_search.rs:143
  kimun_notes::components::drawer_views::TagsPanel::new takes 2 parameters in /tmp/.tmpjrmWPC/kimun-notes/src/components/drawer_views.rs:107, but now takes 3 parameters in /tmp/.tmpW1X6li/kimun/tui/src/components/drawer_views.rs:113
  kimun_notes::components::text_editor::view::MarkdownEditorView::update takes 3 parameters in /tmp/.tmpjrmWPC/kimun-notes/src/components/text_editor/view.rs:281, but now takes 2 parameters in /tmp/.tmpW1X6li/kimun/tui/src/components/text_editor/view.rs:666
  kimun_notes::components::drawer_views::LinksPanel::new takes 2 parameters in /tmp/.tmpjrmWPC/kimun-notes/src/components/drawer_views.rs:341, but now takes 3 parameters in /tmp/.tmpW1X6li/kimun/tui/src/components/drawer_views.rs:351
  kimun_notes::components::query_list_panel::QueryListPanel::new takes 1 parameters in /tmp/.tmpjrmWPC/kimun-notes/src/components/query_list_panel.rs:76, but now takes 2 parameters in /tmp/.tmpW1X6li/kimun/tui/src/components/query_list_panel.rs:79

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod kimun_notes::components::text_editor::word_wrap, previously in file /tmp/.tmpjrmWPC/kimun-notes/src/components/text_editor/word_wrap.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct kimun_notes::components::text_editor::word_wrap::VisualLine, previously in file /tmp/.tmpjrmWPC/kimun-notes/src/components/text_editor/word_wrap.rs:2
  struct kimun_notes::components::text_editor::word_wrap::WordWrapLayout, previously in file /tmp/.tmpjrmWPC/kimun-notes/src/components/text_editor/word_wrap.rs:203

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field lines of struct EditorSnapshot, previously in file /tmp/.tmpjrmWPC/kimun-notes/src/components/text_editor/snapshot.rs:18
  field lines_snapshot of struct MarkdownEditorView, previously in file /tmp/.tmpjrmWPC/kimun-notes/src/components/text_editor/view.rs:48

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait kimun_notes::components::overlay::Overlay gained Send in file /tmp/.tmpW1X6li/kimun/tui/src/components/overlay.rs:49

--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Struct EditorSnapshot (1 -> 0 lifetime params) in /tmp/.tmpW1X6li/kimun/tui/src/components/text_editor/snapshot.rs:16

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  ActionShortcuts::ToggleQueryPanel moved from position 15 to 16, in /tmp/.tmpW1X6li/kimun/tui/src/keys/action_shortcuts.rs:53
  ActionShortcuts::OpenSavedSearches moved from position 16 to 17, in /tmp/.tmpW1X6li/kimun/tui/src/keys/action_shortcuts.rs:54
  ActionShortcuts::SaveCurrentQuery moved from position 17 to 18, in /tmp/.tmpW1X6li/kimun/tui/src/keys/action_shortcuts.rs:55
  ActionShortcuts::OpenAsk moved from position 18 to 19, in /tmp/.tmpW1X6li/kimun/tui/src/keys/action_shortcuts.rs:58
  ActionShortcuts::SwitchWorkspace moved from position 19 to 20, in /tmp/.tmpW1X6li/kimun/tui/src/keys/action_shortcuts.rs:60
  ActionShortcuts::FindInBuffer moved from position 20 to 21, in /tmp/.tmpW1X6li/kimun/tui/src/keys/action_shortcuts.rs:63
  ActionShortcuts::Leader moved from position 21 to 23, in /tmp/.tmpW1X6li/kimun/tui/src/keys/action_shortcuts.rs:70
  ActionShortcuts::OpenCommandPalette moved from position 22 to 24, in /tmp/.tmpW1X6li/kimun/tui/src/keys/action_shortcuts.rs:73
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `kimun_core`

<blockquote>

## [0.2.30](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.29...kimun_core-v0.2.30) - 2026-08-01

### Fixed

- fmt
- position panic
- line breaks are not changed on save
</blockquote>

## `kimun-notes`

<blockquote>

## [0.22.0](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.21.0...kimun-notes-v0.22.0) - 2026-08-01

### Added

- undo coalescing
- up and down arrows move on visual lines
- find and replace
- flash actions on key combos

### Fixed

- home path exansion test
- fmt
- image rendering correct
- overlay fix
- tui and engine consistent rendering
- proper click mapper on links
- rendering
- find match scroll
- blockquote final fix
- blockquote unblock
- record numers correctly the changes
- range performance
- fmt
- position panic
- bugs
- no string vectors
- clippy and benches on CI
- selection bug on search
- correctness on bump
- proper rendering full text on replace
- highlight logical text
- visual fixes
- highlights correct on rendered links
- highlight changes on replace
- bugfixes
- paste images in vim mode
- fixed copy paste on vim mode using ctrl C V X

### Other

- unified tab width definition
- context update
- document overlay improvement opportunity
- document decision on no translator mapping
- position_at_cell
- reset regression
- incremental parse on block
- removed bench
- line delta on edits
- newline decouple
- new benches
- micro otimizations
- async render
- removed ?Send requirement
- test for single undo for wrapping words
- removed reference old code
- key table
- ratatui-textarea out from build
- shim removed on text editor
- vim connection
- wired in the view
- markdown tie in
- tests on ropetext
- performance on keystroke
- no textarea
- snapshot
- highlighting code
- find bar
- consolidate undo
- input ownership
</blockquote>

## `kimun_server_client`

<blockquote>

## [0.2.1](https://github.com/nico2sh/kimun/compare/kimun_server_client-v0.2.0...kimun_server_client-v0.2.1) - 2026-08-01

### Other

- updated the following local packages: kimun_core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).