### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "kimun-notes"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "arboard",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "kimun_core"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "chrono",
  "criterion",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "kimun_server"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.31](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.30...kimun_core-v0.2.31) - 2026-08-02
+
+### Fixed
+
+- folded client and ropetext into tui
+
+### Other
+
+- removed reference documents
+
 ## [0.2.30](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.29...kimun_core-v0.2.30) - 2026-08-01
 
 ### Fixed

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun_core"
-version = "0.2.30"
+version = "0.2.31"
 authors = ["Nico Hormazábal <mail@nico2sh.com>"]
 edition = "2021"
 description = "Core library for the Kimün notes application"

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/nico2sh/kimun/compare/kimun_server-v0.4.0...kimun_server-v0.4.1) - 2026-08-02
+
+### Fixed
+
+- folded client and ropetext into tui
+
+### Other
+
+- removed reference documents
+
 ## [0.4.0](https://github.com/nico2sh/kimun/compare/kimun_server-v0.3.0...kimun_server-v0.4.0) - 2026-07-20
 
 ### Added

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun_server"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 
 [[bin]]

--- a/tui/CHANGELOG.md
+++ b/tui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.22.0...kimun-notes-v0.22.1) - 2026-08-02
+
+### Other
+
+- updated the following local packages: kimun_core
+
 ## [0.22.0](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.21.0...kimun-notes-v0.22.0) - 2026-08-01
 
 ### Added

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun-notes"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2024"
 description = "A terminal-based notes application"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "kimun_notes"
 path = "src/lib.rs"
 
 [dependencies]
-kimun_core = { path = "../core", version = "0.2.30" }
+kimun_core = { path = "../core", version = "0.2.31" }
 
 clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6.5"


### PR DESCRIPTION



## 🤖 New release

* `kimun_core`: 0.2.30 -> 0.2.31 (✓ API compatible changes)
* `kimun_server`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `kimun-notes`: 0.22.0 -> 0.22.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `kimun_core`

<blockquote>

## [0.2.31](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.30...kimun_core-v0.2.31) - 2026-08-02

### Fixed

- folded client and ropetext into tui

### Other

- removed reference documents
</blockquote>

## `kimun_server`

<blockquote>

## [0.4.1](https://github.com/nico2sh/kimun/compare/kimun_server-v0.4.0...kimun_server-v0.4.1) - 2026-08-02

### Fixed

- folded client and ropetext into tui

### Other

- removed reference documents
</blockquote>

## `kimun-notes`

<blockquote>

## [0.22.1](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.22.0...kimun-notes-v0.22.1) - 2026-08-02

### Other

- updated the following local packages: kimun_core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).