### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "kimun-notes"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "arboard",
  "async-trait",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "kimun_core"
-version = "0.2.31"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "criterion",

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.31...kimun_core-v0.3.0) - 2026-08-08
+
+### Added
+
+- *(system)* name the process holding a locked file
+
+### Fixed
+
+- small regression
+- bugs
+- cap the file-lock wait at 3s, not 60s
+- measure the file-lock wait instead of guessing its ceiling
+- raise the Windows file-lock wait to ~9s
+- wait out Windows file locks, unique test vault dirs
+- host-absolute paths in Windows-failing tests
+- small bugs
+- linux build in ci
+- leftover bugs
+- winidows issues
+- winidows path resolution tests
+- tests
+- expand path tests
+- save a llm ask with a proper file name
+
+### Other
+
+- moved utilities functions
+- indeexfile
+- use system module for file operations
+- index as an artifact
+- one single lpace for filesystem operations
+
 ## [0.2.31](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.30...kimun_core-v0.2.31) - 2026-08-02
 
 ### Fixed

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun_core"
-version = "0.2.31"
+version = "0.3.0"
 authors = ["Nico Hormazábal <mail@nico2sh.com>"]
 edition = "2021"
 description = "Core library for the Kimün notes application"

--- a/tui/CHANGELOG.md
+++ b/tui/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.23.0...kimun-notes-v0.24.0) - 2026-08-08
+
+### Added
+
+- name workspace files after an opaque key, not the workspace
+
+### Fixed
+
+- canonical path in test
+- small regression
+- bugs
+- report what remove could not delete, never fail a launch over the index
+- a reused workspace name must not claim another's index
+- rename a workspace without moving its index
+- wait out Windows file locks, unique test vault dirs
+- host-absolute paths in Windows-failing tests
+- small bugs
+- linux build in ci
+- fix test vault close, and unresolved cache fix
+- leftover bugs
+- winidows issues
+- winidows path resolution tests
+- helper for absolute path
+- issue resolving the home path on the first run
+- tests
+- expand path tests
+- save a llm ask with a proper file name
+
+### Other
+
+- drop a public doc link to a private item
+- *(test)* drop mcp_smoke's in-test cargo build
+- indeexfile
+- use system module for file operations
+- index as an artifact
+- one single lpace for filesystem operations
+
 ## [0.23.0](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.22.1...kimun-notes-v0.23.0) - 2026-08-06
 
 ### Added

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kimun-notes"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 description = "A terminal-based notes application"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "kimun_notes"
 path = "src/lib.rs"
 
 [dependencies]
-kimun_core = { path = "../core", version = "0.2.31" }
+kimun_core = { path = "../core", version = "0.3.0" }
 
 clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6.5"


### PR DESCRIPTION



## 🤖 New release

* `kimun_core`: 0.2.31 -> 0.3.0 (⚠ API breaking changes)
* `kimun-notes`: 0.23.0 -> 0.24.0 (⚠ API breaking changes)

### ⚠ `kimun_core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VaultConfig.index in /tmp/.tmpcWCyR5/kimun/core/src/lib.rs:145

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function kimun_core::utilities::ensure_dir_exists, previously in file /tmp/.tmp1hKjpz/kimun_core/src/utilities.rs:67
  function kimun_core::ensure_dir_exists, previously in file /tmp/.tmp1hKjpz/kimun_core/src/utilities.rs:67
  function kimun_core::utilities::path_to_string, previously in file /tmp/.tmp1hKjpz/kimun_core/src/utilities.rs:5
  function kimun_core::utilities::app_log_dir, previously in file /tmp/.tmp1hKjpz/kimun_core/src/utilities.rs:29
  function kimun_core::app_log_dir, previously in file /tmp/.tmp1hKjpz/kimun_core/src/utilities.rs:29
  function kimun_core::utilities::remove_diacritics, previously in file /tmp/.tmp1hKjpz/kimun_core/src/utilities.rs:79

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  VaultConfig::with_db_path, previously in file /tmp/.tmp1hKjpz/kimun_core/src/lib.rs:151

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  kimun_core::nfs::DirectoryEntryData::get_details takes 0 generic types instead of 1, in /tmp/.tmpcWCyR5/kimun/core/src/nfs/mod.rs:139

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod kimun_core::utilities, previously in file /tmp/.tmp1hKjpz/kimun_core/src/utilities.rs:1

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field db_path of struct VaultConfig, previously in file /tmp/.tmp1hKjpz/kimun_core/src/lib.rs:130
```

### ⚠ `kimun-notes` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field WorkspaceEntry.file_key in /tmp/.tmpcWCyR5/kimun/tui/src/settings/workspace_config.rs:104

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant SettingsError:System in /tmp/.tmpcWCyR5/kimun/tui/src/settings/mod.rs:25

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function kimun_notes::settings::history::push_history, previously in file /tmp/.tmp1hKjpz/kimun-notes/src/settings/history.rs:42
  function kimun_notes::settings::history::load_history, previously in file /tmp/.tmp1hKjpz/kimun-notes/src/settings/history.rs:15

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  WorkspaceConfig::from_phase1_migration, previously in file /tmp/.tmp1hKjpz/kimun-notes/src/settings/workspace_config.rs:179
  AppSettings::set_workspace, previously in file /tmp/.tmp1hKjpz/kimun-notes/src/settings/mod.rs:669
  AppSettings::cache_path_for, previously in file /tmp/.tmp1hKjpz/kimun-notes/src/settings/mod.rs:799
  AppSettings::history_path_for, previously in file /tmp/.tmp1hKjpz/kimun-notes/src/settings/mod.rs:809

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field workspace_dir of struct AppSettings, previously in file /tmp/.tmp1hKjpz/kimun-notes/src/settings/mod.rs:151
  field last_paths of struct AppSettings, previously in file /tmp/.tmp1hKjpz/kimun-notes/src/settings/mod.rs:153
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `kimun_core`

<blockquote>

## [0.3.0](https://github.com/nico2sh/kimun/compare/kimun_core-v0.2.31...kimun_core-v0.3.0) - 2026-08-08

### Added

- *(system)* name the process holding a locked file

### Fixed

- small regression
- bugs
- cap the file-lock wait at 3s, not 60s
- measure the file-lock wait instead of guessing its ceiling
- raise the Windows file-lock wait to ~9s
- wait out Windows file locks, unique test vault dirs
- host-absolute paths in Windows-failing tests
- small bugs
- linux build in ci
- leftover bugs
- winidows issues
- winidows path resolution tests
- tests
- expand path tests
- save a llm ask with a proper file name

### Other

- moved utilities functions
- indeexfile
- use system module for file operations
- index as an artifact
- one single lpace for filesystem operations
</blockquote>

## `kimun-notes`

<blockquote>

## [0.24.0](https://github.com/nico2sh/kimun/compare/kimun-notes-v0.23.0...kimun-notes-v0.24.0) - 2026-08-08

### Added

- name workspace files after an opaque key, not the workspace

### Fixed

- canonical path in test
- small regression
- bugs
- report what remove could not delete, never fail a launch over the index
- a reused workspace name must not claim another's index
- rename a workspace without moving its index
- wait out Windows file locks, unique test vault dirs
- host-absolute paths in Windows-failing tests
- small bugs
- linux build in ci
- fix test vault close, and unresolved cache fix
- leftover bugs
- winidows issues
- winidows path resolution tests
- helper for absolute path
- issue resolving the home path on the first run
- tests
- expand path tests
- save a llm ask with a proper file name

### Other

- drop a public doc link to a private item
- *(test)* drop mcp_smoke's in-test cargo build
- indeexfile
- use system module for file operations
- index as an artifact
- one single lpace for filesystem operations
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).